### PR TITLE
phase 10-11: complete public API and concurrent runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,10 @@ tracing = { version = "0.1.44", default-features = false, features = ["std"], op
 zstd = { version = "0.13.3", default-features = false }
 
 [features]
-default = ["std", "compat"]
+default = ["std"]
 std = []
 serde = ["dep:serde"]
 tracing = ["dep:tracing"]
-compat = []
 bench-internals = []
 
 [dev-dependencies]
@@ -63,6 +62,11 @@ test = false
 
 [[bench]]
 name = "public_api"
+harness = false
+test = false
+
+[[bench]]
+name = "concurrent_runtime"
 harness = false
 test = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ test = false
 name = "file_permissions"
 path = "examples/file_permissions.rs"
 
+[[example]]
+name = "collaboration_workspace"
+path = "examples/collaboration_workspace.rs"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pest_derive = "2.8.6"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 thiserror = "2.0.18"
 tracing = { version = "0.1.44", default-features = false, features = ["std"], optional = true }
+zstd = { version = "0.13.3", default-features = false }
 
 [features]
 default = ["std", "compat"]
@@ -57,6 +58,11 @@ test = false
 
 [[bench]]
 name = "snapshot"
+harness = false
+test = false
+
+[[bench]]
+name = "public_api"
 harness = false
 test = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ name = "concurrent_runtime"
 harness = false
 test = false
 
+[[bench]]
+name = "realworld_authorization"
+harness = false
+test = false
+
 [[example]]
 name = "file_permissions"
 path = "examples/file_permissions.rs"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ bench-org-memory:
 bench-snapshot:
 	@cargo bench --bench snapshot -- --sample-size 10
 
+bench-public-api:
+	@cargo bench --bench public_api -- --sample-size 10
+
 bench-snapshot-memory:
 	@cargo bench --bench snapshot --no-run
 	@target_dir=$${CARGO_TARGET_DIR:-$$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}; \
@@ -48,7 +51,7 @@ bench-snapshot-memory:
 	done; \
 	rm -f "$$snapshot_file"
 
-bench-all: bench-baseline bench-org bench-snapshot
+bench-all: bench-baseline bench-org bench-snapshot bench-public-api
 
 fmt:
 	@cargo +nightly fmt
@@ -72,4 +75,4 @@ release:
 update-submodule:
 	@git submodule update --init --recursive --remote
 
-.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule
+.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ bench-public-api:
 bench-concurrent-runtime:
 	@cargo bench --bench concurrent_runtime -- --sample-size 10
 
+bench-realworld:
+	@cargo bench --bench realworld_authorization -- --sample-size 10
+
 bench-snapshot-memory:
 	@cargo bench --bench snapshot --no-run
 	@target_dir=$${CARGO_TARGET_DIR:-$$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}; \
@@ -54,7 +57,7 @@ bench-snapshot-memory:
 	done; \
 	rm -f "$$snapshot_file"
 
-bench-all: bench-baseline bench-org bench-snapshot bench-public-api bench-concurrent-runtime
+bench-all: bench-baseline bench-org bench-snapshot bench-public-api bench-concurrent-runtime bench-realworld
 
 fmt:
 	@cargo +nightly fmt
@@ -78,4 +81,4 @@ release:
 update-submodule:
 	@git submodule update --init --recursive --remote
 
-.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-concurrent-runtime bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule
+.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-concurrent-runtime bench-realworld bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ bench-snapshot:
 bench-public-api:
 	@cargo bench --bench public_api -- --sample-size 10
 
+bench-concurrent-runtime:
+	@cargo bench --bench concurrent_runtime -- --sample-size 10
+
 bench-snapshot-memory:
 	@cargo bench --bench snapshot --no-run
 	@target_dir=$${CARGO_TARGET_DIR:-$$(cargo metadata --format-version 1 --no-deps | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')}; \
@@ -51,7 +54,7 @@ bench-snapshot-memory:
 	done; \
 	rm -f "$$snapshot_file"
 
-bench-all: bench-baseline bench-org bench-snapshot bench-public-api
+bench-all: bench-baseline bench-org bench-snapshot bench-public-api bench-concurrent-runtime
 
 fmt:
 	@cargo +nightly fmt
@@ -75,4 +78,4 @@ release:
 update-submodule:
 	@git submodule update --init --recursive --remote
 
-.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule
+.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-concurrent-runtime bench-snapshot-memory bench-all fmt fmt-check clippy lint release update-submodule

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant Client
-    participant Service as ZanzibarService
+    participant Service as ZanzibarEngine
     participant Parser as DSL Parser
     participant Store as Tuple Store
     participant Eval as Evaluation Engine
@@ -142,10 +142,10 @@ simple-zanzibar = "0.1.0"
 ### Basic Usage
 
 ```rust
-use simple_zanzibar::{ZanzibarService, model::{Object, Relation, RelationTuple, User}};
+use simple_zanzibar::{ZanzibarEngine, model::{Object, Relation, RelationTuple, User}};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Define policy using DSL
     let policy = r#"
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // Check permission
-    let can_view = service.check(
+    let can_view = service.check_relation(
         &doc,
         &Relation("viewer".to_string()),
         &alice
@@ -312,32 +312,32 @@ namespace folder {
 
 ## 🔧 API Reference
 
-### ZanzibarService
+### ZanzibarEngine
 
 The main service for handling authorization.
 
 ```rust
-impl ZanzibarService {
-    // Create a new service
-    pub fn new() -> Self
+impl ZanzibarEngine {
+    // Create a new engine
+    pub fn builder() -> ZanzibarEngineBuilder
 
     // Load policy from DSL
-    pub fn add_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError>
+    pub fn add_dsl(&self, dsl: &str) -> Result<(), EngineError>
 
     // Add namespace configuration
-    pub fn add_config(&mut self, config: NamespaceConfig) -> Result<(), ZanzibarError>
+    pub fn apply_namespace_config(&self, config: NamespaceConfig) -> Result<ConsistencyToken, EngineError>
 
     // Write a relation tuple
-    pub fn write_tuple(&mut self, tuple: RelationTuple) -> Result<(), ZanzibarError>
+    pub fn write_tuple(&self, tuple: impl Borrow<RelationTuple>) -> Result<(), EngineError>
 
     // Delete a relation tuple
-    pub fn delete_tuple(&mut self, tuple: &RelationTuple) -> Result<(), ZanzibarError>
+    pub fn delete_tuple(&self, tuple: &RelationTuple) -> Result<(), EngineError>
 
     // Check if user has relation to object
-    pub fn check(&self, object: &Object, relation: &Relation, user: &User) -> Result<bool, ZanzibarError>
+    pub fn check_relation(&self, object: &Object, relation: &Relation, user: &User) -> Result<bool, EngineError>
 
     // Expand userset for object and relation
-    pub fn expand(&self, object: &Object, relation: &Relation) -> Result<ExpandedUserset, ZanzibarError>
+    pub fn expand_relation(&self, object: &Object, relation: &Relation) -> Result<ExpandedUserset, EngineError>
 }
 ```
 
@@ -385,7 +385,7 @@ This example demonstrates:
 ### Custom Implementation
 
 ```rust
-use simple_zanzibar::{ZanzibarService, model::*};
+use simple_zanzibar::{ZanzibarEngine, model::*};
 
 // Define your domain objects
 let document = Object {
@@ -396,7 +396,7 @@ let document = Object {
 let user = User::UserId("john.doe".to_string());
 
 // Set up your service with policies
-let mut service = ZanzibarService::new();
+let service = ZanzibarEngine::builder().build();
 service.add_dsl(r#"
     namespace document {
         relation owner {}
@@ -419,7 +419,7 @@ service.write_tuple(RelationTuple {
 })?;
 
 // Check permissions
-let can_view = service.check(
+let can_view = service.check_relation(
     &document,
     &Relation("viewer".to_string()),
     &user

--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, hint::black_box, num::NonZeroU32, time::Duration
 
 use criterion::{BatchSize, Criterion};
 use simple_zanzibar::{
-    ZanzibarService,
+    ZanzibarEngine,
     eval::EvaluationLimits,
     model::{
         LookupResourcesRequest, NamespaceConfig, Object, Relation, RelationConfig, RelationTuple,
@@ -81,8 +81,12 @@ fn write_or_abort(store: &mut impl TupleStore, tuple: RelationTuple) {
     }
 }
 
-fn service_with_relationships(count: usize) -> ZanzibarService {
-    let mut service = ZanzibarService::new();
+fn service_with_relationships(count: usize) -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder().build();
+    if let Err(error) = service.apply_namespace_config(owner_namespace()) {
+        eprintln!("failed to build service benchmark schema: {error}");
+        std::process::abort();
+    }
 
     for index in 0..count {
         if let Err(error) = service.write_tuple(owner_tuple(index)) {
@@ -91,16 +95,15 @@ fn service_with_relationships(count: usize) -> ZanzibarService {
         }
     }
 
-    if let Err(error) = service.add_config(owner_namespace()) {
-        eprintln!("failed to build service benchmark schema: {error}");
-        std::process::abort();
-    }
-
     service
 }
 
-fn service_with_one_hop_relationships(count: usize) -> ZanzibarService {
-    let mut service = ZanzibarService::new();
+fn service_with_one_hop_relationships(count: usize) -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder().build();
+    if let Err(error) = service.add_dsl(graph_schema()) {
+        eprintln!("failed to build one-hop benchmark schema: {error}");
+        std::process::abort();
+    }
     let pairs = count / 2;
     for index in 0..pairs {
         if let Err(error) = service.write_tuple(RelationTuple {
@@ -129,15 +132,15 @@ fn service_with_one_hop_relationships(count: usize) -> ZanzibarService {
             std::process::abort();
         }
     }
-    if let Err(error) = service.add_dsl(graph_schema()) {
-        eprintln!("failed to build one-hop benchmark schema: {error}");
-        std::process::abort();
-    }
     service
 }
 
-fn service_with_tuple_to_userset_relationships(count: usize) -> ZanzibarService {
-    let mut service = ZanzibarService::new();
+fn service_with_tuple_to_userset_relationships(count: usize) -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder().build();
+    if let Err(error) = service.add_dsl(graph_schema()) {
+        eprintln!("failed to build tuple-to-userset benchmark schema: {error}");
+        std::process::abort();
+    }
     let pairs = count / 2;
     for index in 0..pairs {
         if let Err(error) = service.write_tuple(RelationTuple {
@@ -166,19 +169,21 @@ fn service_with_tuple_to_userset_relationships(count: usize) -> ZanzibarService 
             std::process::abort();
         }
     }
-    if let Err(error) = service.add_dsl(graph_schema()) {
-        eprintln!("failed to build tuple-to-userset benchmark schema: {error}");
-        std::process::abort();
-    }
     service
 }
 
-fn service_with_lookup_relationships(count: usize) -> ZanzibarService {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero_u32(50),
-        max_fanout_per_step: non_zero_u32(1_000),
-        max_lookup_results: non_zero_u32(u32::try_from(count).unwrap_or(u32::MAX)),
-    });
+fn service_with_lookup_relationships(count: usize) -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero_u32(50),
+            max_fanout_per_step: non_zero_u32(1_000),
+            max_lookup_results: non_zero_u32(u32::try_from(count).unwrap_or(u32::MAX)),
+        })
+        .build();
+    if let Err(error) = service.add_dsl(graph_schema()) {
+        eprintln!("failed to build lookup benchmark schema: {error}");
+        std::process::abort();
+    }
     let viewer = Relation("viewer".to_string());
     let user = User::UserId("lookup-user".to_string());
     for index in 0..count {
@@ -190,10 +195,6 @@ fn service_with_lookup_relationships(count: usize) -> ZanzibarService {
             eprintln!("failed to build lookup benchmark dataset: {error}");
             std::process::abort();
         }
-    }
-    if let Err(error) = service.add_dsl(graph_schema()) {
-        eprintln!("failed to build lookup benchmark schema: {error}");
-        std::process::abort();
     }
     service
 }
@@ -214,7 +215,11 @@ fn bench_indexed_direct_check(c: &mut Criterion) {
 
     c.bench_function("indexed_direct_check_100k", |b| {
         b.iter(|| {
-            black_box(service.check(black_box(&object), black_box(&relation), black_box(&user)))
+            black_box(service.check_relation(
+                black_box(&object),
+                black_box(&relation),
+                black_box(&user),
+            ))
         });
     });
 }
@@ -249,7 +254,11 @@ fn bench_one_hop_userset_check(c: &mut Criterion) {
 
     c.bench_function("one_hop_userset_check_100k", |b| {
         b.iter(|| {
-            black_box(service.check(black_box(&object), black_box(&relation), black_box(&user)))
+            black_box(service.check_relation(
+                black_box(&object),
+                black_box(&relation),
+                black_box(&user),
+            ))
         });
     });
 }
@@ -263,7 +272,11 @@ fn bench_tuple_to_userset_check(c: &mut Criterion) {
 
     c.bench_function("tuple_to_userset_check_100k", |b| {
         b.iter(|| {
-            black_box(service.check(black_box(&object), black_box(&relation), black_box(&user)))
+            black_box(service.check_relation(
+                black_box(&object),
+                black_box(&relation),
+                black_box(&user),
+            ))
         });
     });
 }

--- a/benches/concurrent_runtime.rs
+++ b/benches/concurrent_runtime.rs
@@ -1,0 +1,470 @@
+//! Concurrent runtime benchmarks for lock-free reads and single-writer actor writes.
+
+use std::{
+    env,
+    hint::black_box,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use criterion::Criterion;
+use simple_zanzibar::{
+    TenantId, ZanzibarEngine, ZanzibarTenantShards,
+    eval::EvaluationLimits,
+    model::{Object, Relation, User},
+    relationship::RelationshipMutation,
+};
+
+const BASE_RELATIONSHIPS: usize = 20_000;
+const SEED_BATCH_SIZE: usize = 5_000;
+const WRITER_QUEUE_CAPACITY: usize = 16_384;
+const TARGET_USER: &str = "user-000000";
+
+fn main() {
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let filters = benchmark_filters();
+    let scenarios = scenario_configs();
+    let selected = scenarios
+        .iter()
+        .copied()
+        .filter(|scenario| should_benchmark(scenario.name, &filters))
+        .collect::<Vec<_>>();
+
+    let summary = selected
+        .iter()
+        .copied()
+        .map(run_scenario)
+        .collect::<Vec<_>>();
+    print_markdown_summary(&summary);
+
+    let mut criterion = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(100))
+        .measurement_time(Duration::from_millis(800))
+        .configure_from_args();
+
+    for scenario in selected {
+        criterion.bench_function(scenario.name, |bencher| {
+            bencher.iter_custom(|iterations| {
+                let started = Instant::now();
+                for _ in 0..iterations {
+                    black_box(run_scenario(scenario));
+                }
+                started.elapsed()
+            });
+        });
+    }
+    criterion.final_summary();
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Scenario {
+    name: &'static str,
+    reader_threads: usize,
+    writer_threads: usize,
+    batch_size: usize,
+    writer_pause: Duration,
+    duration: Duration,
+    tenants: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ScenarioStats {
+    name: &'static str,
+    duration: Duration,
+    tenants: usize,
+    reader_threads: usize,
+    writer_threads: usize,
+    batch_size: usize,
+    read_ops: u64,
+    write_api_calls: u64,
+    logical_mutations: u64,
+    write_latency_p50: Duration,
+    write_latency_p95: Duration,
+    write_latency_max: Duration,
+}
+
+#[derive(Debug, Default)]
+struct WriterStats {
+    write_api_calls: u64,
+    logical_mutations: u64,
+    latencies: Vec<Duration>,
+}
+
+fn scenario_configs() -> [Scenario; 6] {
+    [
+        Scenario {
+            name: "concurrent_runtime/read_heavy_light_write_batched",
+            reader_threads: 8,
+            writer_threads: 1,
+            batch_size: 32,
+            writer_pause: Duration::from_millis(25),
+            duration: Duration::from_millis(500),
+            tenants: 1,
+        },
+        Scenario {
+            name: "concurrent_runtime/read_heavy_medium_write_unbatched",
+            reader_threads: 8,
+            writer_threads: 1,
+            batch_size: 1,
+            writer_pause: Duration::ZERO,
+            duration: Duration::from_millis(500),
+            tenants: 1,
+        },
+        Scenario {
+            name: "concurrent_runtime/read_heavy_medium_write_batched",
+            reader_threads: 8,
+            writer_threads: 1,
+            batch_size: 128,
+            writer_pause: Duration::ZERO,
+            duration: Duration::from_millis(500),
+            tenants: 1,
+        },
+        Scenario {
+            name: "concurrent_runtime/read_heavy_heavy_write_unbatched",
+            reader_threads: 8,
+            writer_threads: 4,
+            batch_size: 1,
+            writer_pause: Duration::ZERO,
+            duration: Duration::from_millis(500),
+            tenants: 1,
+        },
+        Scenario {
+            name: "concurrent_runtime/read_heavy_heavy_write_batched",
+            reader_threads: 8,
+            writer_threads: 4,
+            batch_size: 128,
+            writer_pause: Duration::ZERO,
+            duration: Duration::from_millis(500),
+            tenants: 1,
+        },
+        Scenario {
+            name: "concurrent_runtime/tenant_sharded_heavy_write_batched",
+            reader_threads: 8,
+            writer_threads: 4,
+            batch_size: 128,
+            writer_pause: Duration::ZERO,
+            duration: Duration::from_millis(500),
+            tenants: 4,
+        },
+    ]
+}
+
+fn run_scenario(scenario: Scenario) -> ScenarioStats {
+    let engines = build_engines(scenario);
+    let stop = Arc::new(AtomicBool::new(false));
+    let read_ops = Arc::new(AtomicU64::new(0));
+    let sequence = Arc::new(AtomicU64::new(0));
+
+    let readers = spawn_readers(scenario, &engines, &stop, &read_ops);
+    let writers = spawn_writers(scenario, &engines, &stop, &sequence);
+
+    thread::sleep(scenario.duration);
+    stop.store(true, Ordering::Release);
+
+    for reader in readers {
+        join_reader(reader);
+    }
+
+    let mut writer_stats = WriterStats::default();
+    for writer in writers {
+        let local = join_writer(writer);
+        writer_stats.write_api_calls = writer_stats
+            .write_api_calls
+            .saturating_add(local.write_api_calls);
+        writer_stats.logical_mutations = writer_stats
+            .logical_mutations
+            .saturating_add(local.logical_mutations);
+        writer_stats.latencies.extend(local.latencies);
+    }
+
+    writer_stats.latencies.sort_unstable();
+    ScenarioStats {
+        name: scenario.name,
+        duration: scenario.duration,
+        tenants: scenario.tenants,
+        reader_threads: scenario.reader_threads,
+        writer_threads: scenario.writer_threads,
+        batch_size: scenario.batch_size,
+        read_ops: read_ops.load(Ordering::Acquire),
+        write_api_calls: writer_stats.write_api_calls,
+        logical_mutations: writer_stats.logical_mutations,
+        write_latency_p50: percentile(&writer_stats.latencies, 50),
+        write_latency_p95: percentile(&writer_stats.latencies, 95),
+        write_latency_max: percentile(&writer_stats.latencies, 100),
+    }
+}
+
+fn spawn_readers(
+    scenario: Scenario,
+    engines: &[Arc<ZanzibarEngine>],
+    stop: &Arc<AtomicBool>,
+    read_ops: &Arc<AtomicU64>,
+) -> Vec<thread::JoinHandle<()>> {
+    (0..scenario.reader_threads)
+        .map(|index| {
+            let engine = engine_for(engines, index);
+            let stop = Arc::clone(stop);
+            let read_ops = Arc::clone(read_ops);
+            thread::spawn(move || {
+                let object = Object::new("doc", "doc-000000");
+                let relation = Relation::new("viewer");
+                let user = User::user_id(TARGET_USER);
+                let mut local_reads = 0_u64;
+                while !stop.load(Ordering::Acquire) {
+                    let allowed = must(
+                        engine.check_relation(&object, &relation, &user),
+                        "reader check failed",
+                    );
+                    if allowed {
+                        local_reads = local_reads.saturating_add(1);
+                    }
+                }
+                read_ops.fetch_add(local_reads, Ordering::AcqRel);
+            })
+        })
+        .collect()
+}
+
+fn spawn_writers(
+    scenario: Scenario,
+    engines: &[Arc<ZanzibarEngine>],
+    stop: &Arc<AtomicBool>,
+    sequence: &Arc<AtomicU64>,
+) -> Vec<thread::JoinHandle<WriterStats>> {
+    (0..scenario.writer_threads)
+        .map(|index| {
+            let engine = engine_for(engines, index);
+            let stop = Arc::clone(stop);
+            let sequence = Arc::clone(sequence);
+            thread::spawn(move || {
+                let mut stats = WriterStats::default();
+                while !stop.load(Ordering::Acquire) {
+                    let mutations = build_write_batch(scenario.batch_size, &sequence);
+                    let mutation_count = mutations.len();
+                    let started = Instant::now();
+                    must(engine.write_relationships(mutations), "writer batch failed");
+                    stats.latencies.push(started.elapsed());
+                    stats.write_api_calls = stats.write_api_calls.saturating_add(1);
+                    stats.logical_mutations = stats
+                        .logical_mutations
+                        .saturating_add(u64::try_from(mutation_count).unwrap_or(u64::MAX));
+                    if !scenario.writer_pause.is_zero() {
+                        thread::sleep(scenario.writer_pause);
+                    }
+                }
+                stats
+            })
+        })
+        .collect()
+}
+
+fn build_engines(scenario: Scenario) -> Vec<Arc<ZanzibarEngine>> {
+    if scenario.tenants == 1 {
+        return vec![Arc::new(build_engine(BASE_RELATIONSHIPS))];
+    }
+
+    let shards = ZanzibarTenantShards::new(
+        ZanzibarEngine::builder().writer_queue_capacity(non_zero_usize(WRITER_QUEUE_CAPACITY)),
+    );
+    (0..scenario.tenants)
+        .map(|tenant_index| {
+            let tenant = must(
+                TenantId::new(format!("tenant-{tenant_index:02}")),
+                "invalid benchmark tenant id",
+            );
+            let engine = shards.get_or_create(tenant);
+            seed_engine(&engine, BASE_RELATIONSHIPS / scenario.tenants);
+            engine
+        })
+        .collect()
+}
+
+fn build_engine(relationships: usize) -> ZanzibarEngine {
+    let engine = ZanzibarEngine::builder()
+        .writer_queue_capacity(non_zero_usize(WRITER_QUEUE_CAPACITY))
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero_u32(50),
+            max_fanout_per_step: non_zero_u32(100_000),
+            max_lookup_results: non_zero_u32(10_000),
+        })
+        .build();
+    seed_engine(&engine, relationships);
+    engine
+}
+
+fn seed_engine(engine: &ZanzibarEngine, relationships: usize) {
+    must(
+        engine.add_dsl(doc_schema()),
+        "failed to apply benchmark schema",
+    );
+    let mut batch = Vec::with_capacity(SEED_BATCH_SIZE);
+    for index in 0..relationships {
+        batch.push(must(
+            RelationshipMutation::touch(format!("doc:doc-{index:06}#viewer@user:user-{index:06}")),
+            "failed to build seed relationship",
+        ));
+        if batch.len() == SEED_BATCH_SIZE {
+            flush_seed_batch(engine, &mut batch);
+        }
+    }
+    flush_seed_batch(engine, &mut batch);
+}
+
+fn flush_seed_batch(engine: &ZanzibarEngine, batch: &mut Vec<RelationshipMutation>) {
+    if batch.is_empty() {
+        return;
+    }
+    let mutations = std::mem::take(batch);
+    must(
+        engine.write_relationships(mutations),
+        "failed to seed benchmark relationships",
+    );
+}
+
+fn build_write_batch(batch_size: usize, sequence: &AtomicU64) -> Vec<RelationshipMutation> {
+    let mut mutations = Vec::with_capacity(batch_size);
+    for _ in 0..batch_size {
+        let next = sequence.fetch_add(1, Ordering::AcqRel);
+        mutations.push(must(
+            RelationshipMutation::touch(format!(
+                "doc:write-{next:012}#viewer@user:writer-{next:012}",
+            )),
+            "failed to build writer relationship",
+        ));
+    }
+    mutations
+}
+
+fn engine_for(engines: &[Arc<ZanzibarEngine>], index: usize) -> Arc<ZanzibarEngine> {
+    let engine_count = engines.len();
+    if engine_count == 0 {
+        abort("benchmark requires at least one engine");
+    }
+    let engine_index = index % engine_count;
+    match engines.get(engine_index) {
+        Some(engine) => Arc::clone(engine),
+        None => abort("benchmark engine index out of range"),
+    }
+}
+
+fn join_reader(handle: thread::JoinHandle<()>) {
+    if handle.join().is_err() {
+        abort("reader thread panicked");
+    }
+}
+
+fn join_writer(handle: thread::JoinHandle<WriterStats>) -> WriterStats {
+    match handle.join() {
+        Ok(stats) => stats,
+        Err(_) => abort("writer thread panicked"),
+    }
+}
+
+fn percentile(values: &[Duration], percentile: usize) -> Duration {
+    if values.is_empty() {
+        return Duration::ZERO;
+    }
+    let last_index = values.len().saturating_sub(1);
+    let rank = last_index.saturating_mul(percentile) / 100;
+    match values.get(rank) {
+        Some(value) => *value,
+        None => Duration::ZERO,
+    }
+}
+
+fn print_markdown_summary(stats: &[ScenarioStats]) {
+    if stats.is_empty() {
+        return;
+    }
+    println!();
+    println!("concurrent runtime benchmark summary");
+    println!(
+        "| scenario | tenants | readers | writers | batch | read ops/s | write calls/s | logical \
+         writes/s | write p50 | write p95 | write max |",
+    );
+    println!("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+    for stat in stats {
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+            stat.name,
+            stat.tenants,
+            stat.reader_threads,
+            stat.writer_threads,
+            stat.batch_size,
+            per_second(stat.read_ops, stat.duration),
+            per_second(stat.write_api_calls, stat.duration),
+            per_second(stat.logical_mutations, stat.duration),
+            micros(stat.write_latency_p50),
+            micros(stat.write_latency_p95),
+            micros(stat.write_latency_max),
+        );
+    }
+    println!();
+}
+
+fn per_second(count: u64, duration: Duration) -> u64 {
+    let nanos = duration.as_nanos();
+    if nanos == 0 {
+        return 0;
+    }
+    let scaled = u128::from(count).saturating_mul(1_000_000_000) / nanos;
+    u64::try_from(scaled).unwrap_or(u64::MAX)
+}
+
+fn micros(duration: Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+fn benchmark_filters() -> Vec<String> {
+    env::args()
+        .skip(1)
+        .filter(|argument| !argument.starts_with("--"))
+        .collect()
+}
+
+fn should_benchmark(name: &str, filters: &[String]) -> bool {
+    filters.is_empty() || filters.iter().any(|filter| name.contains(filter))
+}
+
+fn doc_schema() -> &'static str {
+    r"
+    namespace doc {
+        relation viewer {}
+    }
+    "
+}
+
+fn non_zero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => NonZeroU32::MIN,
+    }
+}
+
+fn non_zero_usize(value: usize) -> NonZeroUsize {
+    match NonZeroUsize::new(value) {
+        Some(value) => value,
+        None => NonZeroUsize::MIN,
+    }
+}
+
+fn must<T, E: std::fmt::Display>(result: Result<T, E>, message: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => abort(&format!("{message}: {error}")),
+    }
+}
+
+fn abort(message: &str) -> ! {
+    eprintln!("{message}");
+    std::process::abort();
+}

--- a/benches/org_authorization.rs
+++ b/benches/org_authorization.rs
@@ -11,7 +11,7 @@ use std::{
 
 use criterion::{BatchSize, Criterion};
 use simple_zanzibar::{
-    ZanzibarService,
+    ZanzibarEngine,
     domain::{RelationName, Relationship, SubjectId, SubjectRef, SubjectType},
     eval::{
         EvaluationLimits, check_with_snapshot, expand_with_snapshot,
@@ -84,8 +84,8 @@ fn bench_building_blocks(criterion: &mut Criterion, filters: &[String]) {
     if should_benchmark(schema_name, filters) {
         criterion.bench_function(schema_name, |bencher| {
             bencher.iter_batched(
-                ZanzibarService::new,
-                |mut service| {
+                || ZanzibarEngine::builder().build(),
+                |service| {
                     must(
                         service.add_dsl(black_box(org_schema())),
                         "failed to apply schema",
@@ -102,8 +102,8 @@ fn bench_building_blocks(criterion: &mut Criterion, filters: &[String]) {
         criterion.bench_function(write_name, |bencher| {
             bencher.iter_batched(
                 configured_service,
-                |mut service| {
-                    apply_generated_relationships(&mut service, WRITE_BATCH_RULES);
+                |service| {
+                    apply_generated_relationships(&service, WRITE_BATCH_RULES);
                     black_box(service)
                 },
                 BatchSize::LargeInput,
@@ -364,9 +364,11 @@ fn build_org_scenario(rules: usize) -> OrgScenario {
     scenario
 }
 
-fn configured_service() -> ZanzibarService {
-    let mut service = ZanzibarService::with_snapshot_retention(non_zero_usize(1))
-        .with_evaluation_limits(evaluation_limits());
+fn configured_service() -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder()
+        .retained_snapshots(non_zero_usize(1))
+        .evaluation_limits(evaluation_limits())
+        .build();
     must(
         service.add_dsl(org_schema()),
         "failed to apply organization schema",
@@ -515,7 +517,7 @@ fn ensure_check(
     }
 }
 
-fn apply_generated_relationships(service: &mut ZanzibarService, rules: usize) {
+fn apply_generated_relationships(service: &ZanzibarEngine, rules: usize) {
     let fixed_relationships = fixed_relationships();
     let mut batch = Vec::with_capacity(MUTATION_BATCH_LIMIT);
 
@@ -548,7 +550,7 @@ fn apply_generated_store_relationships(store: &mut IndexedRelationshipStore, rul
 }
 
 fn push_relationship(
-    service: &mut ZanzibarService,
+    service: &ZanzibarEngine,
     batch: &mut Vec<RelationshipMutation>,
     relationship: Relationship,
 ) {
@@ -558,14 +560,14 @@ fn push_relationship(
     }
 }
 
-fn flush_relationships(service: &mut ZanzibarService, batch: &mut Vec<RelationshipMutation>) {
+fn flush_relationships(service: &ZanzibarEngine, batch: &mut Vec<RelationshipMutation>) {
     if batch.is_empty() {
         return;
     }
 
     let mutations = std::mem::take(batch);
     must(
-        service.apply_relationship_mutations(mutations, []),
+        service.write_relationships_with_preconditions(mutations, []),
         "failed to apply generated relationship batch",
     );
 }

--- a/benches/public_api.rs
+++ b/benches/public_api.rs
@@ -12,7 +12,6 @@ use std::{
 use criterion::{BatchSize, Criterion};
 use simple_zanzibar::{
     PolicyText, SnapshotCompression, SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
-    ZanzibarService,
     domain::Relationship,
     eval::EvaluationLimits,
     model::{
@@ -291,7 +290,7 @@ fn bench_write_apis(criterion: &mut Criterion, filters: &[String], policy: &Poli
     }
 }
 
-fn bench_policy_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarService) {
+fn bench_policy_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarEngine) {
     let export_name = "public_api/export_policy_text/100k";
     if should_benchmark(export_name, filters) {
         criterion.bench_function(export_name, |bencher| {
@@ -324,7 +323,7 @@ fn bench_policy_apis(criterion: &mut Criterion, filters: &[String], service: &Za
     }
 }
 
-fn bench_snapshot_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarService) {
+fn bench_snapshot_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarEngine) {
     let save_raw_name = "public_api/snapshot_save_uncompressed/100k";
     if should_benchmark(save_raw_name, filters) {
         criterion.bench_function(save_raw_name, |bencher| {
@@ -392,11 +391,13 @@ fn bench_snapshot_apis(criterion: &mut Criterion, filters: &[String], service: &
     }
 }
 
-fn build_service_with_relationships(rules: usize) -> ZanzibarService {
-    let mut service = ZanzibarService::new().with_evaluation_limits(evaluation_limits());
+fn build_service_with_relationships(rules: usize) -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(evaluation_limits())
+        .build();
     must(service.add_dsl(org_schema()), "failed to apply org schema");
     let relationships = generated_relationships(rules);
-    apply_relationships(&mut service, &relationships);
+    apply_relationships(&service, &relationships);
     service
 }
 
@@ -408,7 +409,7 @@ fn evaluation_limits() -> EvaluationLimits {
     }
 }
 
-fn apply_relationships(service: &mut ZanzibarService, relationships: &[Relationship]) {
+fn apply_relationships(service: &ZanzibarEngine, relationships: &[Relationship]) {
     let mut batch = Vec::with_capacity(MUTATION_BATCH_LIMIT);
     for relationship in relationships {
         batch.push(RelationshipMutation::Touch(relationship.clone()));
@@ -419,13 +420,13 @@ fn apply_relationships(service: &mut ZanzibarService, relationships: &[Relations
     flush_relationships(service, &mut batch);
 }
 
-fn flush_relationships(service: &mut ZanzibarService, batch: &mut Vec<RelationshipMutation>) {
+fn flush_relationships(service: &ZanzibarEngine, batch: &mut Vec<RelationshipMutation>) {
     if batch.is_empty() {
         return;
     }
     let mutations = std::mem::take(batch);
     must(
-        service.apply_relationship_mutations(mutations, []),
+        service.write_relationships_with_preconditions(mutations, []),
         "failed to apply relationship batch",
     );
 }
@@ -581,7 +582,7 @@ fn zstd_load_options() -> SnapshotLoadOptions {
 }
 
 fn prepared_snapshot(
-    service: &ZanzibarService,
+    service: &ZanzibarEngine,
     options: SnapshotSaveOptions,
     label: &str,
 ) -> PathBuf {

--- a/benches/public_api.rs
+++ b/benches/public_api.rs
@@ -1,0 +1,713 @@
+//! Benchmarks for public API operations.
+
+use std::{
+    env, fs,
+    hint::black_box,
+    num::NonZeroU32,
+    path::{Path, PathBuf},
+    process,
+    time::Duration,
+};
+
+use criterion::{BatchSize, Criterion};
+use simple_zanzibar::{
+    PolicyText, SnapshotCompression, SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
+    ZanzibarService,
+    domain::Relationship,
+    eval::EvaluationLimits,
+    model::{
+        CheckRequest, ExpandRequest, LookupObjectPermissionsRequest, LookupPermissionsRequest,
+        LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, User,
+    },
+    relationship::RelationshipMutation,
+    revision::Consistency,
+    schema::SchemaSource,
+};
+
+const DATASET_RULES: usize = 100_000;
+const SMALL_DATASET_RULES: usize = 1_000;
+const MUTATION_BATCH_LIMIT: usize = 10_000;
+const FIXED_RELATIONSHIP_COUNT: usize = 9;
+const TARGET_USER_ID: &str = "target_user";
+const EDITOR_USER_ID: &str = "editor_user";
+const OWNER_USER_ID: &str = "owner_user";
+
+fn main() {
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let filters = benchmark_filters();
+    let mut criterion = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(100))
+        .measurement_time(Duration::from_millis(500))
+        .configure_from_args();
+
+    let service = build_service_with_relationships(DATASET_RULES);
+    let policy = must(service.export_policy_text(), "failed to export policy text");
+    let engine = must(
+        ZanzibarEngine::from_policy_text(&policy),
+        "failed to build engine from policy text",
+    );
+
+    bench_schema_apis(&mut criterion, &filters);
+    bench_read_apis(&mut criterion, &filters, &engine);
+    bench_write_apis(&mut criterion, &filters, &policy);
+    bench_policy_apis(&mut criterion, &filters, &service);
+    bench_snapshot_apis(&mut criterion, &filters, &service);
+    criterion.final_summary();
+}
+
+fn bench_schema_apis(criterion: &mut Criterion, filters: &[String]) {
+    let apply_name = "public_api/apply_schema/small";
+    if should_benchmark(apply_name, filters) {
+        criterion.bench_function(apply_name, |bencher| {
+            bencher.iter_batched(
+                ZanzibarEngine::default,
+                |engine| {
+                    black_box(must(
+                        engine.apply_schema(SchemaSource {
+                            name: Some("org"),
+                            text: org_schema(),
+                        }),
+                        "apply_schema failed",
+                    ))
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    let replace_name = "public_api/replace_schema/small";
+    if should_benchmark(replace_name, filters) {
+        criterion.bench_function(replace_name, |bencher| {
+            bencher.iter_batched(
+                || {
+                    let engine = ZanzibarEngine::default();
+                    must(
+                        engine.apply_schema(SchemaSource {
+                            name: Some("initial"),
+                            text: unused_schema(),
+                        }),
+                        "initial apply_schema failed",
+                    );
+                    engine
+                },
+                |engine| {
+                    black_box(must(
+                        engine.replace_schema(SchemaSource {
+                            name: Some("org"),
+                            text: org_schema(),
+                        }),
+                        "replace_schema failed",
+                    ))
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    let delete_relation_name = "public_api/delete_relation/small";
+    if should_benchmark(delete_relation_name, filters) {
+        criterion.bench_function(delete_relation_name, |bencher| {
+            bencher.iter_batched(
+                unused_policy_engine,
+                |engine| {
+                    black_box(must(
+                        engine.delete_relation("doc", "unused"),
+                        "delete failed",
+                    ))
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    let delete_namespace_name = "public_api/delete_namespace/small";
+    if should_benchmark(delete_namespace_name, filters) {
+        criterion.bench_function(delete_namespace_name, |bencher| {
+            bencher.iter_batched(
+                unused_policy_engine,
+                |engine| black_box(must(engine.delete_namespace("unused"), "delete failed")),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn bench_read_apis(criterion: &mut Criterion, filters: &[String], engine: &ZanzibarEngine) {
+    let target_user = User::UserId(TARGET_USER_ID.to_string());
+    let can_view = relation("can_view");
+    let direct_doc = object("doc", "direct_doc");
+    let inherited_doc = object("doc", "inherited_doc");
+
+    let check_name = "public_api/check/100k";
+    if should_benchmark(check_name, filters) {
+        criterion.bench_function(check_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.check(CheckRequest::new(
+                        black_box(direct_doc.clone()),
+                        black_box(can_view.clone()),
+                        black_box(target_user.clone()),
+                        Consistency::Latest,
+                    )),
+                    "check failed",
+                ))
+            });
+        });
+    }
+
+    let expand_name = "public_api/expand/100k";
+    if should_benchmark(expand_name, filters) {
+        criterion.bench_function(expand_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.expand(ExpandRequest::new(
+                        black_box(inherited_doc.clone()),
+                        black_box(can_view.clone()),
+                        Consistency::Latest,
+                    )),
+                    "expand failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_resources_name = "public_api/lookup_resources/100k";
+    if should_benchmark(lookup_resources_name, filters) {
+        let request = LookupResourcesRequest {
+            subject: target_user.clone(),
+            permission: can_view.clone(),
+            resource_type: "doc".to_string(),
+        };
+        criterion.bench_function(lookup_resources_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.lookup_resources(black_box(request.clone())),
+                    "lookup_resources failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_subjects_name = "public_api/lookup_subjects/100k";
+    if should_benchmark(lookup_subjects_name, filters) {
+        let request = LookupSubjectsRequest {
+            resource: direct_doc.clone(),
+            permission: can_view.clone(),
+            subject_type: "user".to_string(),
+        };
+        criterion.bench_function(lookup_subjects_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.lookup_subjects(black_box(request.clone())),
+                    "lookup_subjects failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_permissions_name = "public_api/lookup_permissions/100k";
+    if should_benchmark(lookup_permissions_name, filters) {
+        let request = LookupPermissionsRequest {
+            subject: target_user.clone(),
+            resource: inherited_doc.clone(),
+            consistency: Consistency::Latest,
+        };
+        criterion.bench_function(lookup_permissions_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.lookup_permissions(black_box(request.clone())),
+                    "lookup_permissions failed",
+                ))
+            });
+        });
+    }
+
+    let object_permissions_name = "public_api/lookup_object_permissions/100k";
+    if should_benchmark(object_permissions_name, filters) {
+        let request = LookupObjectPermissionsRequest {
+            resource: direct_doc,
+            subject_type: "user".to_string(),
+            consistency: Consistency::Latest,
+        };
+        criterion.bench_function(object_permissions_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    engine.lookup_object_permissions(black_box(request.clone())),
+                    "lookup_object_permissions failed",
+                ))
+            });
+        });
+    }
+}
+
+fn bench_write_apis(criterion: &mut Criterion, filters: &[String], policy: &PolicyText) {
+    let write_name = "public_api/write_relationships/1k_batch";
+    if should_benchmark(write_name, filters) {
+        let mutations = generated_extra_relationships(1_000)
+            .into_iter()
+            .map(RelationshipMutation::Touch)
+            .collect::<Vec<_>>();
+        criterion.bench_function(write_name, |bencher| {
+            bencher.iter_batched(
+                || {
+                    must(
+                        ZanzibarEngine::from_policy_text(policy),
+                        "engine build failed",
+                    )
+                },
+                |engine| {
+                    black_box(must(
+                        engine.write_relationships(mutations.clone()),
+                        "write_relationships failed",
+                    ))
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    let apply_policy_name = "public_api/apply_policy_text/1k";
+    if should_benchmark(apply_policy_name, filters) {
+        let small_policy = must(
+            build_service_with_relationships(SMALL_DATASET_RULES).export_policy_text(),
+            "small policy export failed",
+        );
+        criterion.bench_function(apply_policy_name, |bencher| {
+            bencher.iter_batched(
+                ZanzibarEngine::default,
+                |engine| {
+                    black_box(must(
+                        engine.apply_policy_text(black_box(&small_policy)),
+                        "apply_policy_text failed",
+                    ))
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+}
+
+fn bench_policy_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarService) {
+    let export_name = "public_api/export_policy_text/100k";
+    if should_benchmark(export_name, filters) {
+        criterion.bench_function(export_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    service.export_policy_text(),
+                    "export_policy_text failed",
+                ))
+            });
+        });
+    }
+
+    let export_files_name = "public_api/export_policy_files/1k";
+    if should_benchmark(export_files_name, filters) {
+        let small_service = build_service_with_relationships(SMALL_DATASET_RULES);
+        criterion.bench_function(export_files_name, |bencher| {
+            bencher.iter_batched(
+                || unique_path("policy_export"),
+                |path| {
+                    must(
+                        small_service.export_policy_files(&path),
+                        "export_policy_files failed",
+                    );
+                    remove_directory(&path);
+                    black_box(path)
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+}
+
+fn bench_snapshot_apis(criterion: &mut Criterion, filters: &[String], service: &ZanzibarService) {
+    let save_raw_name = "public_api/snapshot_save_uncompressed/100k";
+    if should_benchmark(save_raw_name, filters) {
+        criterion.bench_function(save_raw_name, |bencher| {
+            bencher.iter_batched(
+                || unique_path("save_raw").with_extension("szsnap"),
+                |path| {
+                    must(
+                        service.save_snapshot(&path, SnapshotSaveOptions::default()),
+                        "raw snapshot save failed",
+                    );
+                    let len = must(fs::metadata(&path), "raw snapshot metadata failed").len();
+                    remove_file(&path);
+                    black_box(len)
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    let load_raw_name = "public_api/snapshot_load_uncompressed/100k";
+    if should_benchmark(load_raw_name, filters) {
+        let path = prepared_snapshot(service, SnapshotSaveOptions::default(), "load_raw");
+        criterion.bench_function(load_raw_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default()),
+                    "raw snapshot load failed",
+                ))
+            });
+        });
+        remove_file(&path);
+    }
+
+    let save_zstd_name = "public_api/snapshot_save_zstd/100k";
+    if should_benchmark(save_zstd_name, filters) {
+        criterion.bench_function(save_zstd_name, |bencher| {
+            bencher.iter_batched(
+                || unique_path("save_zstd").with_extension("szsnap.zst"),
+                |path| {
+                    must(
+                        service.save_snapshot(&path, zstd_save_options()),
+                        "zstd snapshot save failed",
+                    );
+                    let len = must(fs::metadata(&path), "zstd snapshot metadata failed").len();
+                    remove_file(&path);
+                    black_box(len)
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    let load_zstd_name = "public_api/snapshot_load_zstd/100k";
+    if should_benchmark(load_zstd_name, filters) {
+        let path = prepared_snapshot(service, zstd_save_options(), "load_zstd");
+        criterion.bench_function(load_zstd_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    ZanzibarEngine::load_snapshot(&path, zstd_load_options()),
+                    "zstd snapshot load failed",
+                ))
+            });
+        });
+        remove_file(&path);
+    }
+}
+
+fn build_service_with_relationships(rules: usize) -> ZanzibarService {
+    let mut service = ZanzibarService::new().with_evaluation_limits(evaluation_limits());
+    must(service.add_dsl(org_schema()), "failed to apply org schema");
+    let relationships = generated_relationships(rules);
+    apply_relationships(&mut service, &relationships);
+    service
+}
+
+fn evaluation_limits() -> EvaluationLimits {
+    EvaluationLimits {
+        max_depth: non_zero_u32(50),
+        max_fanout_per_step: non_zero_u32(100_000),
+        max_lookup_results: non_zero_u32(1_000),
+    }
+}
+
+fn apply_relationships(service: &mut ZanzibarService, relationships: &[Relationship]) {
+    let mut batch = Vec::with_capacity(MUTATION_BATCH_LIMIT);
+    for relationship in relationships {
+        batch.push(RelationshipMutation::Touch(relationship.clone()));
+        if batch.len() == MUTATION_BATCH_LIMIT {
+            flush_relationships(service, &mut batch);
+        }
+    }
+    flush_relationships(service, &mut batch);
+}
+
+fn flush_relationships(service: &mut ZanzibarService, batch: &mut Vec<RelationshipMutation>) {
+    if batch.is_empty() {
+        return;
+    }
+    let mutations = std::mem::take(batch);
+    must(
+        service.apply_relationship_mutations(mutations, []),
+        "failed to apply relationship batch",
+    );
+}
+
+fn generated_relationships(rules: usize) -> Vec<Relationship> {
+    let mut relationships = Vec::with_capacity(rules);
+    relationships.extend(fixed_relationships());
+    let generated = rules.saturating_sub(FIXED_RELATIONSHIP_COUNT);
+    for index in 0..generated {
+        relationships.push(generated_relationship(index));
+    }
+    relationships
+}
+
+fn generated_extra_relationships(count: usize) -> Vec<Relationship> {
+    (0..count)
+        .map(|index| {
+            parse_relationship(format!(
+                "doc:write_doc_{index:06}#viewer@user:write_user_{index:06}",
+            ))
+        })
+        .collect()
+}
+
+fn generated_relationship(index: usize) -> Relationship {
+    match index % 6 {
+        0 => parse_relationship(format!(
+            "doc:bulk_doc_{index:06}#viewer@group:target_team#member",
+        )),
+        1 => parse_relationship(format!(
+            "doc:bulk_doc_{index:06}#parent@folder:bulk_folder_{:05}#inherited_viewer",
+            index / 100,
+        )),
+        2 => parse_relationship(format!(
+            "folder:bulk_folder_{:05}#viewer@group:bulk_team_{:05}#member",
+            index / 100,
+            index % 10_000,
+        )),
+        3 => parse_relationship(format!(
+            "group:bulk_team_{:05}#member@user:bulk_user_{index:06}",
+            index % 10_000,
+        )),
+        4 => parse_relationship(format!(
+            "doc:bulk_doc_{index:06}#editor@group:bulk_team_{:05}#member",
+            index % 10_000,
+        )),
+        _ => parse_relationship(format!(
+            "doc:bulk_doc_{index:06}#banned@user:blocked_user_{index:06}",
+        )),
+    }
+}
+
+fn fixed_relationships() -> [Relationship; FIXED_RELATIONSHIP_COUNT] {
+    [
+        parse_relationship(format!("group:target_team#member@user:{TARGET_USER_ID}")),
+        parse_relationship("folder:target_folder#viewer@group:target_team#member"),
+        parse_relationship("doc:inherited_doc#parent@folder:target_folder#inherited_viewer"),
+        parse_relationship("doc:direct_doc#viewer@group:target_team#member"),
+        parse_relationship("doc:denied_doc#viewer@group:target_team#member"),
+        parse_relationship(format!("doc:denied_doc#banned@user:{TARGET_USER_ID}")),
+        parse_relationship(format!("group:edit_team#member@user:{EDITOR_USER_ID}")),
+        parse_relationship("doc:edit_doc#editor@group:edit_team#member"),
+        parse_relationship(format!("doc:owner_doc#owner@user:{OWNER_USER_ID}")),
+    ]
+}
+
+fn org_schema() -> &'static str {
+    r#"
+    namespace group {
+        relation member {}
+    }
+
+    namespace folder {
+        relation viewer {}
+        relation editor {}
+        relation owner {}
+
+        relation inherited_viewer {
+            rewrite union(
+                this,
+                computed_userset(relation: "viewer"),
+                computed_userset(relation: "editor"),
+                computed_userset(relation: "owner")
+            )
+        }
+    }
+
+    namespace doc {
+        relation parent {}
+        relation viewer {}
+        relation editor {}
+        relation owner {}
+        relation banned {}
+
+        relation can_view {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "viewer"),
+                    computed_userset(relation: "editor"),
+                    computed_userset(relation: "owner"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "inherited_viewer")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_edit {
+            rewrite union(
+                computed_userset(relation: "editor"),
+                computed_userset(relation: "owner")
+            )
+        }
+    }
+    "#
+}
+
+fn unused_schema() -> &'static str {
+    r"
+    namespace unused {
+        relation member {}
+    }
+
+    namespace doc {
+        relation unused {}
+    }
+    "
+}
+
+fn unused_policy_engine() -> ZanzibarEngine {
+    let engine = ZanzibarEngine::default();
+    must(
+        engine.apply_schema(SchemaSource {
+            name: Some("unused"),
+            text: unused_schema(),
+        }),
+        "unused schema failed",
+    );
+    engine
+}
+
+fn zstd_save_options() -> SnapshotSaveOptions {
+    SnapshotSaveOptions {
+        compression: SnapshotCompression::Zstd,
+        ..SnapshotSaveOptions::default()
+    }
+}
+
+fn zstd_load_options() -> SnapshotLoadOptions {
+    SnapshotLoadOptions {
+        compression: SnapshotCompression::Zstd,
+        ..SnapshotLoadOptions::default()
+    }
+}
+
+fn prepared_snapshot(
+    service: &ZanzibarService,
+    options: SnapshotSaveOptions,
+    label: &str,
+) -> PathBuf {
+    let path = unique_path(label).with_extension(match options.compression {
+        SnapshotCompression::None => "szsnap",
+        SnapshotCompression::Zstd => "szsnap.zst",
+    });
+    must(
+        service.save_snapshot(&path, options),
+        "failed to prepare snapshot",
+    );
+    path
+}
+
+fn parse_relationship(value: impl AsRef<str>) -> Relationship {
+    must(
+        value.as_ref().parse(),
+        "failed to parse benchmark relationship",
+    )
+}
+
+fn object(namespace: &str, id: &str) -> Object {
+    Object::new(namespace, id)
+}
+
+fn relation(name: &str) -> Relation {
+    Relation::new(name)
+}
+
+fn unique_path(label: &str) -> PathBuf {
+    env::temp_dir().join(format!(
+        "simple_zanzibar_public_api_bench_{label}_{}_{}",
+        process::id(),
+        unique_suffix(),
+    ))
+}
+
+fn unique_suffix() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_SUFFIX: AtomicU64 = AtomicU64::new(1);
+    NEXT_SUFFIX.fetch_add(1, Ordering::Relaxed)
+}
+
+fn remove_file(path: &Path) {
+    let _ = fs::remove_file(path);
+}
+
+fn remove_directory(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn benchmark_filters() -> Vec<String> {
+    let mut filters = Vec::new();
+    let mut skip_next = false;
+
+    for argument in env::args().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if argument == "--bench" {
+            continue;
+        }
+        if option_takes_value(argument.as_str()) {
+            skip_next = !argument.contains('=');
+            continue;
+        }
+        if argument.starts_with('-') {
+            continue;
+        }
+        filters.push(argument);
+    }
+    filters
+}
+
+fn option_takes_value(argument: &str) -> bool {
+    matches!(
+        argument,
+        "--sample-size"
+            | "--warm-up-time"
+            | "--measurement-time"
+            | "--nresamples"
+            | "--confidence-level"
+            | "--significance-level"
+            | "--noise-threshold"
+            | "--profile-time"
+            | "--plotting-backend"
+            | "--save-baseline"
+            | "--baseline"
+            | "--load-baseline"
+            | "--output-format"
+    ) || argument.starts_with("--sample-size=")
+        || argument.starts_with("--warm-up-time=")
+        || argument.starts_with("--measurement-time=")
+        || argument.starts_with("--nresamples=")
+        || argument.starts_with("--confidence-level=")
+        || argument.starts_with("--significance-level=")
+        || argument.starts_with("--noise-threshold=")
+        || argument.starts_with("--profile-time=")
+        || argument.starts_with("--plotting-backend=")
+        || argument.starts_with("--save-baseline=")
+        || argument.starts_with("--baseline=")
+        || argument.starts_with("--load-baseline=")
+        || argument.starts_with("--output-format=")
+}
+
+fn should_benchmark(name: &str, filters: &[String]) -> bool {
+    filters.is_empty() || filters.iter().any(|filter| name.contains(filter.as_str()))
+}
+
+fn non_zero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => NonZeroU32::MIN,
+    }
+}
+
+fn must<T, E>(result: Result<T, E>, context: &str) -> T
+where
+    E: std::fmt::Display,
+{
+    match result {
+        Ok(value) => value,
+        Err(error) => {
+            eprintln!("{context}: {error}");
+            process::abort();
+        }
+    }
+}

--- a/benches/realworld_authorization.rs
+++ b/benches/realworld_authorization.rs
@@ -1,0 +1,979 @@
+//! Benchmarks for a realistic multi-tenant collaboration authorization workload.
+
+use std::{
+    env, fs,
+    hint::black_box,
+    num::NonZeroU32,
+    path::{Path, PathBuf},
+    process,
+    time::Duration,
+};
+
+use criterion::{BenchmarkGroup, Criterion, measurement::WallTime};
+use simple_zanzibar::{
+    SnapshotIntegrityMode, SnapshotLoadOptions, SnapshotSaveOptions, SnapshotValidationMode,
+    ZanzibarEngine,
+    eval::EvaluationLimits,
+    model::{
+        CheckRequest, ExpandRequest, LookupObjectPermissionsRequest, LookupPermissionsRequest,
+        LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, User,
+    },
+    relationship::RelationshipMutation,
+    revision::Consistency,
+};
+
+const SCALES: [WorkloadScale; 2] = [
+    WorkloadScale {
+        label: "100k",
+        relationships: 100_000,
+    },
+    WorkloadScale {
+        label: "1m",
+        relationships: 1_000_000,
+    },
+];
+const MUTATION_BATCH_LIMIT: usize = 10_000;
+const TARGET_USER: &str = "target_user";
+const DIRECT_USER: &str = "direct_user";
+const EDITOR_USER: &str = "editor_user";
+const OWNER_USER: &str = "owner_user";
+const AUDITOR_USER: &str = "auditor_user";
+const BLOCKED_USER: &str = "blocked_user";
+
+#[derive(Debug, Clone, Copy)]
+struct WorkloadScale {
+    label: &'static str,
+    relationships: usize,
+}
+
+#[derive(Debug)]
+struct RealworldScenario {
+    engine: ZanzibarEngine,
+    inherited_doc: Object,
+    direct_doc: Object,
+    denied_doc: Object,
+    shared_doc: Object,
+    launch_project: Object,
+    can_view: Relation,
+    can_edit: Relation,
+    can_share: Relation,
+    target_user: User,
+    direct_user: User,
+    editor_user: User,
+    blocked_user: User,
+    lookup_resources: LookupResourcesRequest,
+    lookup_subjects: LookupSubjectsRequest,
+    lookup_permissions: LookupPermissionsRequest,
+    lookup_object_permissions: LookupObjectPermissionsRequest,
+    expand_shared_doc: ExpandRequest,
+}
+
+fn main() {
+    if cfg!(debug_assertions) {
+        return;
+    }
+
+    let filters = benchmark_filters();
+    let mut criterion = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(100))
+        .measurement_time(Duration::from_millis(500))
+        .configure_from_args();
+
+    for scale in SCALES {
+        if should_build_scale(scale, &filters) {
+            bench_scale(&mut criterion, scale, &filters);
+        }
+    }
+
+    criterion.final_summary();
+}
+
+fn bench_scale(criterion: &mut Criterion, scale: WorkloadScale, filters: &[String]) {
+    let group_name = format!("realworld_authorization/{}_rules", scale.label);
+    let read_benchmarks = [
+        "check_doc_inherited_workspace_member",
+        "check_doc_direct_user",
+        "check_doc_denied_by_ban",
+        "check_doc_project_editor",
+        "lookup_resources_target_user",
+        "lookup_subjects_shared_doc",
+        "lookup_permissions_shared_doc",
+        "lookup_object_permissions_shared_doc",
+        "expand_shared_doc",
+        "mixed_read_workload",
+    ];
+    let snapshot_benchmarks = [
+        "snapshot_load_compact",
+        "snapshot_load_trusted_fast",
+        "snapshot_file_size",
+    ];
+
+    let read_requested = read_benchmarks
+        .iter()
+        .any(|benchmark| should_benchmark(&format!("{group_name}/{benchmark}"), filters));
+    let snapshot_requested = snapshot_benchmarks
+        .iter()
+        .any(|benchmark| should_benchmark(&format!("{group_name}/{benchmark}"), filters));
+
+    let scenario = if read_requested || snapshot_requested {
+        Some(build_scenario(scale.relationships))
+    } else {
+        None
+    };
+
+    if let Some(scenario) = scenario.as_ref()
+        && read_requested
+    {
+        bench_reads(criterion, &group_name, filters, scenario);
+    }
+
+    if let Some(scenario) = scenario.as_ref()
+        && snapshot_requested
+    {
+        bench_snapshot_artifacts(criterion, &group_name, filters, scenario, scale);
+    }
+}
+
+fn bench_reads(
+    criterion: &mut Criterion,
+    group_name: &str,
+    filters: &[String],
+    scenario: &RealworldScenario,
+) {
+    let mut group = criterion.benchmark_group(group_name);
+    bench_check_reads(&mut group, group_name, filters, scenario);
+    bench_lookup_reads(&mut group, group_name, filters, scenario);
+    bench_expand_and_mixed_reads(&mut group, group_name, filters, scenario);
+    group.finish();
+}
+
+fn bench_check_reads(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    group_name: &str,
+    filters: &[String],
+    scenario: &RealworldScenario,
+) {
+    let inherited_name = "check_doc_inherited_workspace_member";
+    if should_benchmark(&format!("{group_name}/{inherited_name}"), filters) {
+        bench_check_read(
+            group,
+            inherited_name,
+            scenario,
+            CheckRead {
+                object: &scenario.inherited_doc,
+                relation: &scenario.can_view,
+                user: &scenario.target_user,
+                context: "inherited check failed",
+            },
+        );
+    }
+
+    let direct_name = "check_doc_direct_user";
+    if should_benchmark(&format!("{group_name}/{direct_name}"), filters) {
+        bench_check_read(
+            group,
+            direct_name,
+            scenario,
+            CheckRead {
+                object: &scenario.direct_doc,
+                relation: &scenario.can_view,
+                user: &scenario.direct_user,
+                context: "direct check failed",
+            },
+        );
+    }
+
+    let denied_name = "check_doc_denied_by_ban";
+    if should_benchmark(&format!("{group_name}/{denied_name}"), filters) {
+        bench_check_read(
+            group,
+            denied_name,
+            scenario,
+            CheckRead {
+                object: &scenario.denied_doc,
+                relation: &scenario.can_view,
+                user: &scenario.blocked_user,
+                context: "denied check failed",
+            },
+        );
+    }
+
+    let editor_name = "check_doc_project_editor";
+    if should_benchmark(&format!("{group_name}/{editor_name}"), filters) {
+        bench_check_read(
+            group,
+            editor_name,
+            scenario,
+            CheckRead {
+                object: &scenario.inherited_doc,
+                relation: &scenario.can_edit,
+                user: &scenario.editor_user,
+                context: "editor check failed",
+            },
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CheckRead<'a> {
+    object: &'a Object,
+    relation: &'a Relation,
+    user: &'a User,
+    context: &'static str,
+}
+
+fn bench_check_read(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    name: &str,
+    scenario: &RealworldScenario,
+    read: CheckRead<'_>,
+) {
+    group.bench_function(name, |bencher| {
+        bencher.iter(|| {
+            black_box(must(
+                scenario.engine.check(black_box(CheckRequest::new(
+                    read.object.clone(),
+                    read.relation.clone(),
+                    read.user.clone(),
+                    Consistency::Latest,
+                ))),
+                read.context,
+            ))
+        });
+    });
+}
+
+fn bench_lookup_reads(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    group_name: &str,
+    filters: &[String],
+    scenario: &RealworldScenario,
+) {
+    let lookup_resources_name = "lookup_resources_target_user";
+    if should_benchmark(&format!("{group_name}/{lookup_resources_name}"), filters) {
+        group.bench_function(lookup_resources_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    scenario
+                        .engine
+                        .lookup_resources(black_box(scenario.lookup_resources.clone())),
+                    "lookup resources failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_subjects_name = "lookup_subjects_shared_doc";
+    if should_benchmark(&format!("{group_name}/{lookup_subjects_name}"), filters) {
+        group.bench_function(lookup_subjects_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    scenario
+                        .engine
+                        .lookup_subjects(black_box(scenario.lookup_subjects.clone())),
+                    "lookup subjects failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_permissions_name = "lookup_permissions_shared_doc";
+    if should_benchmark(&format!("{group_name}/{lookup_permissions_name}"), filters) {
+        group.bench_function(lookup_permissions_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    scenario
+                        .engine
+                        .lookup_permissions(black_box(scenario.lookup_permissions.clone())),
+                    "lookup permissions failed",
+                ))
+            });
+        });
+    }
+
+    let lookup_object_permissions_name = "lookup_object_permissions_shared_doc";
+    if should_benchmark(
+        &format!("{group_name}/{lookup_object_permissions_name}"),
+        filters,
+    ) {
+        group.bench_function(lookup_object_permissions_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    scenario.engine.lookup_object_permissions(black_box(
+                        scenario.lookup_object_permissions.clone(),
+                    )),
+                    "lookup object permissions failed",
+                ))
+            });
+        });
+    }
+}
+
+fn bench_expand_and_mixed_reads(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    group_name: &str,
+    filters: &[String],
+    scenario: &RealworldScenario,
+) {
+    let expand_name = "expand_shared_doc";
+    if should_benchmark(&format!("{group_name}/{expand_name}"), filters) {
+        group.bench_function(expand_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    scenario
+                        .engine
+                        .expand(black_box(scenario.expand_shared_doc.clone())),
+                    "expand failed",
+                ))
+            });
+        });
+    }
+
+    let mixed_name = "mixed_read_workload";
+    if should_benchmark(&format!("{group_name}/{mixed_name}"), filters) {
+        group.bench_function(mixed_name, |bencher| {
+            bencher.iter(|| black_box(run_mixed_read_workload(scenario)));
+        });
+    }
+}
+
+fn bench_snapshot_artifacts(
+    criterion: &mut Criterion,
+    group_name: &str,
+    filters: &[String],
+    scenario: &RealworldScenario,
+    scale: WorkloadScale,
+) {
+    let load_name = "snapshot_load_compact";
+    let trusted_name = "snapshot_load_trusted_fast";
+    let size_name = "snapshot_file_size";
+    let needs_snapshot = [load_name, trusted_name, size_name]
+        .iter()
+        .any(|name| should_benchmark(&format!("{group_name}/{name}"), filters));
+    if !needs_snapshot {
+        return;
+    }
+
+    let path = prepared_snapshot(scenario, scale);
+    let mut group = criterion.benchmark_group(group_name);
+
+    if should_benchmark(&format!("{group_name}/{load_name}"), filters) {
+        group.bench_function(load_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default()),
+                    "snapshot load failed",
+                ))
+            });
+        });
+    }
+
+    if should_benchmark(&format!("{group_name}/{trusted_name}"), filters) {
+        group.bench_function(trusted_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    ZanzibarEngine::load_snapshot(&path, trusted_fast_load_options()),
+                    "trusted snapshot load failed",
+                ))
+            });
+        });
+    }
+
+    if should_benchmark(&format!("{group_name}/{size_name}"), filters) {
+        let len = must(fs::metadata(&path), "snapshot metadata failed").len();
+        eprintln!("{group_name}/{size_name}: {len} bytes");
+        group.bench_function(size_name, |bencher| {
+            bencher.iter(|| black_box(len));
+        });
+    }
+
+    group.finish();
+    remove_file(&path);
+}
+
+fn run_mixed_read_workload(scenario: &RealworldScenario) -> usize {
+    let mut allowed = 0_usize;
+    let checks = [
+        (
+            scenario.inherited_doc.clone(),
+            scenario.can_view.clone(),
+            scenario.target_user.clone(),
+        ),
+        (
+            scenario.direct_doc.clone(),
+            scenario.can_view.clone(),
+            scenario.direct_user.clone(),
+        ),
+        (
+            scenario.denied_doc.clone(),
+            scenario.can_view.clone(),
+            scenario.blocked_user.clone(),
+        ),
+        (
+            scenario.inherited_doc.clone(),
+            scenario.can_edit.clone(),
+            scenario.editor_user.clone(),
+        ),
+        (
+            scenario.shared_doc.clone(),
+            scenario.can_share.clone(),
+            scenario.editor_user.clone(),
+        ),
+    ];
+
+    for (object, relation, user) in checks {
+        let response = must(
+            scenario.engine.check(CheckRequest::new(
+                object,
+                relation,
+                user,
+                Consistency::Latest,
+            )),
+            "mixed check failed",
+        );
+        if response.allowed {
+            allowed = allowed.saturating_add(1);
+        }
+    }
+
+    allowed = allowed.saturating_add(
+        must(
+            scenario
+                .engine
+                .lookup_resources(scenario.lookup_resources.clone()),
+            "mixed lookup resources failed",
+        )
+        .resources
+        .len(),
+    );
+    allowed = allowed.saturating_add(
+        must(
+            scenario
+                .engine
+                .lookup_subjects(scenario.lookup_subjects.clone()),
+            "mixed lookup subjects failed",
+        )
+        .subjects
+        .len(),
+    );
+    allowed = allowed.saturating_add(
+        must(
+            scenario
+                .engine
+                .lookup_permissions(scenario.lookup_permissions.clone()),
+            "mixed lookup permissions failed",
+        )
+        .permissions
+        .len(),
+    );
+    allowed
+}
+
+fn build_scenario(relationships: usize) -> RealworldScenario {
+    let engine = ZanzibarEngine::builder()
+        .evaluation_limits(evaluation_limits())
+        .build();
+    must(
+        engine.add_dsl(REALWORLD_SCHEMA),
+        "failed to apply realworld schema",
+    );
+    apply_relationships(&engine, relationships);
+
+    let scenario = RealworldScenario {
+        engine,
+        inherited_doc: object("doc", "tenant_000_doc_inherited"),
+        direct_doc: object("doc", "tenant_000_doc_direct"),
+        denied_doc: object("doc", "tenant_000_doc_denied"),
+        shared_doc: object("doc", "tenant_000_doc_shared"),
+        launch_project: object("project", "tenant_000_project_000"),
+        can_view: relation("can_view"),
+        can_edit: relation("can_edit"),
+        can_share: relation("can_share"),
+        target_user: user(TARGET_USER),
+        direct_user: user(DIRECT_USER),
+        editor_user: user(EDITOR_USER),
+        blocked_user: user(BLOCKED_USER),
+        lookup_resources: LookupResourcesRequest::new(
+            user(TARGET_USER),
+            relation("can_view"),
+            "doc",
+        ),
+        lookup_subjects: LookupSubjectsRequest::new(
+            object("doc", "tenant_000_doc_shared"),
+            relation("can_view"),
+            "user",
+        ),
+        lookup_permissions: LookupPermissionsRequest::new(
+            user(EDITOR_USER),
+            object("doc", "tenant_000_doc_shared"),
+            Consistency::Latest,
+        ),
+        lookup_object_permissions: LookupObjectPermissionsRequest::new(
+            object("doc", "tenant_000_doc_shared"),
+            "user",
+            Consistency::Latest,
+        ),
+        expand_shared_doc: ExpandRequest::new(
+            object("doc", "tenant_000_doc_shared"),
+            relation("can_view"),
+            Consistency::Latest,
+        ),
+    };
+
+    validate_scenario(&scenario);
+    scenario
+}
+
+fn validate_scenario(scenario: &RealworldScenario) {
+    ensure_check(
+        scenario,
+        &scenario.inherited_doc,
+        &scenario.can_view,
+        &scenario.target_user,
+        true,
+        "target user inherits doc view through workspace membership",
+    );
+    ensure_check(
+        scenario,
+        &scenario.direct_doc,
+        &scenario.can_view,
+        &scenario.direct_user,
+        true,
+        "direct user can view direct doc",
+    );
+    ensure_check(
+        scenario,
+        &scenario.denied_doc,
+        &scenario.can_view,
+        &scenario.blocked_user,
+        false,
+        "blocked user denied by doc ban",
+    );
+    ensure_check(
+        scenario,
+        &scenario.inherited_doc,
+        &scenario.can_edit,
+        &scenario.editor_user,
+        true,
+        "project editor inherits doc edit",
+    );
+    ensure_check(
+        scenario,
+        &scenario.shared_doc,
+        &scenario.can_share,
+        &scenario.editor_user,
+        true,
+        "doc editor can share",
+    );
+    ensure_check(
+        scenario,
+        &scenario.launch_project,
+        &relation("can_view"),
+        &user(AUDITOR_USER),
+        true,
+        "workspace auditor can view project",
+    );
+}
+
+fn ensure_check(
+    scenario: &RealworldScenario,
+    object: &Object,
+    relation: &Relation,
+    user: &User,
+    expected: bool,
+    context: &str,
+) {
+    let actual = must(
+        scenario.engine.check(CheckRequest::new(
+            object.clone(),
+            relation.clone(),
+            user.clone(),
+            Consistency::Latest,
+        )),
+        context,
+    )
+    .allowed;
+    if actual != expected {
+        abort(&format!("{context}: expected {expected}, got {actual}"));
+    }
+}
+
+fn apply_relationships(engine: &ZanzibarEngine, relationships: usize) {
+    let fixed = fixed_relationships();
+    let generated = relationships.saturating_sub(fixed.len());
+    let mut batch = Vec::with_capacity(MUTATION_BATCH_LIMIT);
+
+    for relationship in fixed {
+        push_mutation(engine, &mut batch, relationship);
+    }
+
+    for index in 0..generated {
+        push_mutation(engine, &mut batch, generated_relationship(index));
+    }
+
+    flush_batch(engine, &mut batch);
+}
+
+fn push_mutation(
+    engine: &ZanzibarEngine,
+    batch: &mut Vec<RelationshipMutation>,
+    relationship: String,
+) {
+    batch.push(must(
+        RelationshipMutation::touch(relationship),
+        "failed to parse benchmark relationship",
+    ));
+    if batch.len() == MUTATION_BATCH_LIMIT {
+        flush_batch(engine, batch);
+    }
+}
+
+fn flush_batch(engine: &ZanzibarEngine, batch: &mut Vec<RelationshipMutation>) {
+    if batch.is_empty() {
+        return;
+    }
+    let mutations = std::mem::take(batch);
+    must(
+        engine.write_relationships(mutations),
+        "failed to apply benchmark relationships",
+    );
+}
+
+fn fixed_relationships() -> Vec<String> {
+    [
+        format!("group:tenant_000_members#member@user:{TARGET_USER}"),
+        format!("workspace:tenant_000#owner@user:{OWNER_USER}"),
+        "workspace:tenant_000#member@group:tenant_000_members#member".to_string(),
+        format!("workspace:tenant_000#auditor@user:{AUDITOR_USER}"),
+        "project:tenant_000_project_000#parent@workspace:tenant_000#viewer".to_string(),
+        format!("project:tenant_000_project_000#editor@user:{EDITOR_USER}"),
+        "folder:tenant_000_folder_000#parent@project:tenant_000_project_000#can_view".to_string(),
+        format!("folder:tenant_000_folder_000#editor@user:{EDITOR_USER}"),
+        "doc:tenant_000_doc_inherited#parent@folder:tenant_000_folder_000#can_view".to_string(),
+        format!("doc:tenant_000_doc_direct#viewer@user:{DIRECT_USER}"),
+        "doc:tenant_000_doc_denied#parent@folder:tenant_000_folder_000#can_view".to_string(),
+        format!("doc:tenant_000_doc_denied#banned@user:{BLOCKED_USER}"),
+        format!("doc:tenant_000_doc_shared#editor@user:{EDITOR_USER}"),
+        "doc:tenant_000_doc_shared#viewer@group:tenant_000_members#member".to_string(),
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn generated_relationship(index: usize) -> String {
+    let cohort = index / 10;
+    let tenant = cohort % 128;
+    let team = cohort % 20_000;
+    let project = cohort % 50_000;
+    let folder = cohort % 100_000;
+    let target_team = if cohort.is_multiple_of(100) { 0 } else { team };
+
+    match index % 10 {
+        0 => format!("group:tenant_{tenant:03}_team_{team:05}#member@user:user_{cohort:07}"),
+        1 => format!(
+            "workspace:tenant_{tenant:03}#member@group:tenant_{tenant:03}_team_{team:05}#member",
+        ),
+        2 => format!("workspace:tenant_{tenant:03}#auditor@user:auditor_{cohort:07}"),
+        3 => format!(
+            "project:tenant_{tenant:03}_project_{project:05}#parent@workspace:tenant_{tenant:03}#\
+             viewer",
+        ),
+        4 => format!(
+            "project:tenant_{tenant:03}_project_{project:05}#editor@group:tenant_{tenant:\
+             03}_team_{team:05}#member",
+        ),
+        5 => format!(
+            "folder:tenant_{tenant:03}_folder_{folder:06}#parent@project:tenant_{tenant:\
+             03}_project_{project:05}#can_view",
+        ),
+        6 => format!("folder:tenant_{tenant:03}_folder_{folder:06}#editor@user:editor_{cohort:07}"),
+        7 => format!(
+            "doc:tenant_{tenant:03}_doc_{cohort:07}#parent@folder:tenant_{tenant:\
+             03}_folder_{folder:06}#can_view",
+        ),
+        8 => format!(
+            "doc:tenant_{tenant:03}_doc_{cohort:07}#viewer@group:tenant_{tenant:\
+             03}_team_{target_team:05}#member",
+        ),
+        _ => format!("doc:tenant_{tenant:03}_doc_{cohort:07}#banned@user:blocked_{cohort:07}"),
+    }
+}
+
+fn prepared_snapshot(scenario: &RealworldScenario, scale: WorkloadScale) -> PathBuf {
+    let path = env::temp_dir().join(format!(
+        "simple_zanzibar_realworld_{}_{}_{}.szsnap",
+        scale.label,
+        process::id(),
+        unique_suffix(),
+    ));
+    must(
+        scenario
+            .engine
+            .save_snapshot(&path, SnapshotSaveOptions::default()),
+        "failed to save realworld snapshot",
+    );
+    path
+}
+
+fn trusted_fast_load_options() -> SnapshotLoadOptions {
+    SnapshotLoadOptions {
+        validation: SnapshotValidationMode::TrustedFastLoad,
+        integrity: SnapshotIntegrityMode::External,
+        ..SnapshotLoadOptions::default()
+    }
+}
+
+const REALWORLD_SCHEMA: &str = r#"
+    namespace group {
+        relation member {}
+    }
+
+    namespace workspace {
+        relation owner {}
+        relation member {}
+        relation auditor {}
+
+        relation admin {
+            rewrite computed_userset(relation: "owner")
+        }
+
+        relation viewer {
+            rewrite union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "member"),
+                computed_userset(relation: "auditor")
+            )
+        }
+
+        relation editor {
+            rewrite union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "member")
+            )
+        }
+    }
+
+    namespace project {
+        relation parent {}
+        relation owner {}
+        relation editor {}
+        relation viewer {}
+        relation banned {}
+
+        relation can_view {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    computed_userset(relation: "viewer"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_edit {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "editor")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_admin {
+            rewrite computed_userset(relation: "owner")
+        }
+    }
+
+    namespace folder {
+        relation parent {}
+        relation owner {}
+        relation editor {}
+        relation viewer {}
+        relation banned {}
+
+        relation can_view {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    computed_userset(relation: "viewer"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "can_view")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_edit {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "can_edit")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+    }
+
+    namespace doc {
+        relation parent {}
+        relation owner {}
+        relation editor {}
+        relation viewer {}
+        relation banned {}
+
+        relation can_view {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    computed_userset(relation: "viewer"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "can_view")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_edit {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "editor"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "can_edit")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+
+        relation can_share {
+            rewrite union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "editor")
+            )
+        }
+    }
+    "#;
+
+fn evaluation_limits() -> EvaluationLimits {
+    EvaluationLimits {
+        max_depth: non_zero_u32(50),
+        max_fanout_per_step: non_zero_u32(100_000),
+        max_lookup_results: non_zero_u32(1_000),
+    }
+}
+
+fn object(namespace: &str, id: &str) -> Object {
+    Object::new(namespace, id)
+}
+
+fn relation(name: &str) -> Relation {
+    Relation::new(name)
+}
+
+fn user(id: &str) -> User {
+    User::user_id(id)
+}
+
+fn should_build_scale(scale: WorkloadScale, filters: &[String]) -> bool {
+    let prefix = format!("realworld_authorization/{}_rules", scale.label);
+    filters.is_empty()
+        || filters
+            .iter()
+            .any(|filter| prefix.contains(filter) || filter.contains(scale.label))
+}
+
+fn benchmark_filters() -> Vec<String> {
+    let mut filters = Vec::new();
+    let mut skip_next = false;
+
+    for argument in env::args().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if argument == "--bench" {
+            continue;
+        }
+        if option_takes_value(argument.as_str()) {
+            skip_next = !argument.contains('=');
+            continue;
+        }
+        if argument.starts_with('-') {
+            continue;
+        }
+        filters.push(argument);
+    }
+    filters
+}
+
+fn option_takes_value(argument: &str) -> bool {
+    matches!(
+        argument,
+        "--sample-size"
+            | "--warm-up-time"
+            | "--measurement-time"
+            | "--nresamples"
+            | "--confidence-level"
+            | "--significance-level"
+            | "--noise-threshold"
+            | "--profile-time"
+            | "--plotting-backend"
+            | "--save-baseline"
+            | "--baseline"
+            | "--load-baseline"
+            | "--output-format"
+    ) || argument.starts_with("--sample-size=")
+        || argument.starts_with("--warm-up-time=")
+        || argument.starts_with("--measurement-time=")
+        || argument.starts_with("--nresamples=")
+        || argument.starts_with("--confidence-level=")
+        || argument.starts_with("--significance-level=")
+        || argument.starts_with("--noise-threshold=")
+        || argument.starts_with("--profile-time=")
+        || argument.starts_with("--plotting-backend=")
+        || argument.starts_with("--save-baseline=")
+        || argument.starts_with("--baseline=")
+        || argument.starts_with("--load-baseline=")
+        || argument.starts_with("--output-format=")
+}
+
+fn should_benchmark(name: &str, filters: &[String]) -> bool {
+    filters.is_empty() || filters.iter().any(|filter| name.contains(filter.as_str()))
+}
+
+fn unique_suffix() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT_SUFFIX: AtomicU64 = AtomicU64::new(1);
+    NEXT_SUFFIX.fetch_add(1, Ordering::Relaxed)
+}
+
+fn remove_file(path: &Path) {
+    let _ = fs::remove_file(path);
+}
+
+fn non_zero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => NonZeroU32::MIN,
+    }
+}
+
+fn must<T, E>(result: Result<T, E>, context: &str) -> T
+where
+    E: std::fmt::Display,
+{
+    match result {
+        Ok(value) => value,
+        Err(error) => abort(&format!("{context}: {error}")),
+    }
+}
+
+fn abort(message: &str) -> ! {
+    eprintln!("{message}");
+    process::abort();
+}

--- a/benches/snapshot.rs
+++ b/benches/snapshot.rs
@@ -11,8 +11,8 @@ use std::{
 
 use criterion::{BatchSize, Criterion};
 use simple_zanzibar::{
-    SnapshotIntegrityMode, SnapshotLoadOptions, SnapshotLoadProfile, SnapshotSaveOptions,
-    SnapshotValidationMode, ZanzibarEngine,
+    SnapshotCompression, SnapshotIntegrityMode, SnapshotLoadOptions, SnapshotLoadProfile,
+    SnapshotSaveOptions, SnapshotValidationMode, ZanzibarEngine,
     domain::Relationship,
     eval::EvaluationLimits,
     model::{LookupResourcesRequest, Object, Relation, User},
@@ -92,25 +92,44 @@ fn bench_snapshot_build(criterion: &mut Criterion, filters: &[String]) {
 
 fn bench_snapshot_save(criterion: &mut Criterion, filters: &[String]) {
     let name = "snapshot_save_uncompressed/1m";
-    if !should_benchmark(name, filters) {
-        return;
+    if should_benchmark(name, filters) {
+        let service = build_service_with_relationships(1_000_000);
+        criterion.bench_function(name, |bencher| {
+            bencher.iter_batched(
+                || unique_snapshot_path("save_1m"),
+                |path| {
+                    must(
+                        service.save_snapshot(&path, SnapshotSaveOptions::default()),
+                        "failed to save snapshot",
+                    );
+                    let metadata = must(fs::metadata(&path), "failed to stat saved snapshot");
+                    remove_file(&path);
+                    black_box(metadata.len())
+                },
+                BatchSize::LargeInput,
+            );
+        });
     }
-    let service = build_service_with_relationships(1_000_000);
-    criterion.bench_function(name, |bencher| {
-        bencher.iter_batched(
-            || unique_snapshot_path("save_1m"),
-            |path| {
-                must(
-                    service.save_snapshot(&path, SnapshotSaveOptions::default()),
-                    "failed to save snapshot",
-                );
-                let metadata = must(fs::metadata(&path), "failed to stat saved snapshot");
-                remove_file(&path);
-                black_box(metadata.len())
-            },
-            BatchSize::LargeInput,
-        );
-    });
+
+    let zstd_name = "snapshot_save_zstd/1m";
+    if should_benchmark(zstd_name, filters) {
+        let service = build_service_with_relationships(1_000_000);
+        criterion.bench_function(zstd_name, |bencher| {
+            bencher.iter_batched(
+                || unique_snapshot_path("save_zstd_1m"),
+                |path| {
+                    must(
+                        service.save_snapshot(&path, zstd_save_options()),
+                        "failed to save zstd snapshot",
+                    );
+                    let metadata = must(fs::metadata(&path), "failed to stat zstd snapshot");
+                    remove_file(&path);
+                    black_box(metadata.len())
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
 }
 
 fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
@@ -158,6 +177,20 @@ fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
                         },
                     ),
                     "failed to load and reindex snapshot",
+                ))
+            });
+        });
+        remove_file_if_owned(&path);
+    }
+
+    let zstd_name = "snapshot_load_zstd/1m";
+    if should_benchmark(zstd_name, filters) {
+        let path = prepared_snapshot_file_with_options(1_000_000, zstd_name, zstd_save_options());
+        criterion.bench_function(zstd_name, |bencher| {
+            bencher.iter(|| {
+                black_box(must(
+                    ZanzibarEngine::load_snapshot(&path, zstd_load_options()),
+                    "failed to load zstd compact snapshot",
                 ))
             });
         });
@@ -291,19 +324,37 @@ fn bench_loaded_query_set(
 
 fn bench_snapshot_file_size(criterion: &mut Criterion, filters: &[String]) {
     let name = "snapshot_file_size/1m";
-    if !should_benchmark(name, filters) {
-        return;
+    if should_benchmark(name, filters) {
+        let path = prepared_snapshot_file(1_000_000, name);
+        let len = must(fs::metadata(&path), "failed to stat snapshot file").len();
+        eprintln!("{name}: {len} bytes");
+        criterion.bench_function(name, |bencher| {
+            bencher.iter(|| black_box(len));
+        });
+        remove_file_if_owned(&path);
     }
-    let path = prepared_snapshot_file(1_000_000, name);
-    let len = must(fs::metadata(&path), "failed to stat snapshot file").len();
-    eprintln!("{name}: {len} bytes");
-    criterion.bench_function(name, |bencher| {
-        bencher.iter(|| black_box(len));
-    });
-    remove_file_if_owned(&path);
+
+    let zstd_name = "snapshot_file_size_zstd/1m";
+    if should_benchmark(zstd_name, filters) {
+        let path = prepared_snapshot_file_with_options(1_000_000, zstd_name, zstd_save_options());
+        let len = must(fs::metadata(&path), "failed to stat zstd snapshot file").len();
+        eprintln!("{zstd_name}: {len} bytes");
+        criterion.bench_function(zstd_name, |bencher| {
+            bencher.iter(|| black_box(len));
+        });
+        remove_file_if_owned(&path);
+    }
 }
 
 fn prepared_snapshot_file(rules: usize, benchmark_name: &str) -> PathBuf {
+    prepared_snapshot_file_with_options(rules, benchmark_name, SnapshotSaveOptions::default())
+}
+
+fn prepared_snapshot_file_with_options(
+    rules: usize,
+    benchmark_name: &str,
+    options: SnapshotSaveOptions,
+) -> PathBuf {
     if benchmark_name == "snapshot_load_peak_rss/1m"
         && let Ok(path) = env::var(LOAD_PATH_ENV)
     {
@@ -313,7 +364,7 @@ fn prepared_snapshot_file(rules: usize, benchmark_name: &str) -> PathBuf {
     let path = unique_snapshot_path(rule_label(rules));
     let service = build_service_with_relationships(rules);
     must(
-        service.save_snapshot(&path, SnapshotSaveOptions::default()),
+        service.save_snapshot(&path, options),
         "failed to prepare snapshot file",
     );
     path
@@ -333,6 +384,20 @@ fn trusted_fast_load_options() -> SnapshotLoadOptions {
     SnapshotLoadOptions {
         validation: SnapshotValidationMode::TrustedFastLoad,
         integrity: SnapshotIntegrityMode::External,
+        ..SnapshotLoadOptions::default()
+    }
+}
+
+fn zstd_save_options() -> SnapshotSaveOptions {
+    SnapshotSaveOptions {
+        compression: SnapshotCompression::Zstd,
+        ..SnapshotSaveOptions::default()
+    }
+}
+
+fn zstd_load_options() -> SnapshotLoadOptions {
+    SnapshotLoadOptions {
+        compression: SnapshotCompression::Zstd,
         ..SnapshotLoadOptions::default()
     }
 }

--- a/benches/snapshot.rs
+++ b/benches/snapshot.rs
@@ -12,7 +12,7 @@ use std::{
 use criterion::{BatchSize, Criterion};
 use simple_zanzibar::{
     SnapshotIntegrityMode, SnapshotLoadOptions, SnapshotLoadProfile, SnapshotSaveOptions,
-    SnapshotValidationMode, ZanzibarService,
+    SnapshotValidationMode, ZanzibarEngine,
     domain::Relationship,
     eval::EvaluationLimits,
     model::{LookupResourcesRequest, Object, Relation, User},
@@ -47,7 +47,7 @@ fn main() {
         && let Ok(path) = env::var(LOAD_PATH_ENV)
     {
         let service = must(
-            ZanzibarService::load_snapshot(path, SnapshotLoadOptions::default()),
+            ZanzibarEngine::load_snapshot(path, SnapshotLoadOptions::default()),
             "failed to load snapshot once for RSS measurement",
         );
         black_box(service);
@@ -80,8 +80,8 @@ fn bench_snapshot_build(criterion: &mut Criterion, filters: &[String]) {
         criterion.bench_function(&name, |bencher| {
             bencher.iter_batched(
                 configured_service,
-                |mut service| {
-                    apply_relationships(&mut service, &relationships);
+                |service| {
+                    apply_relationships(&service, &relationships);
                     black_box(service)
                 },
                 BatchSize::LargeInput,
@@ -121,7 +121,7 @@ fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
             criterion.bench_function(&name, |bencher| {
                 bencher.iter(|| {
                     black_box(must(
-                        ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::default()),
+                        ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default()),
                         "failed to load compact snapshot",
                     ))
                 });
@@ -136,7 +136,7 @@ fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
         criterion.bench_function(trusted_name, |bencher| {
             bencher.iter(|| {
                 black_box(must(
-                    ZanzibarService::load_snapshot(&path, trusted_fast_load_options()),
+                    ZanzibarEngine::load_snapshot(&path, trusted_fast_load_options()),
                     "failed to trusted-load compact snapshot",
                 ))
             });
@@ -150,7 +150,7 @@ fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
         criterion.bench_function(reindex_name, |bencher| {
             bencher.iter(|| {
                 black_box(must(
-                    ZanzibarService::load_snapshot(
+                    ZanzibarEngine::load_snapshot(
                         &path,
                         SnapshotLoadOptions {
                             profile: SnapshotLoadProfile::Latency,
@@ -170,7 +170,7 @@ fn bench_snapshot_load(criterion: &mut Criterion, filters: &[String]) {
         criterion.bench_function(rss_name, |bencher| {
             bencher.iter(|| {
                 black_box(must(
-                    ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::default()),
+                    ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default()),
                     "failed to load compact snapshot for RSS",
                 ))
             });
@@ -199,14 +199,14 @@ fn bench_snapshot_loaded_queries(criterion: &mut Criterion, filters: &[String]) 
     let path = prepared_snapshot_file(1_000_000, "snapshot_loaded_queries/1m");
     if full_requested {
         let service = must(
-            ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::default()),
+            ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default()),
             "failed to load snapshot for loaded-query benchmarks",
         );
         bench_loaded_query_set(criterion, filters, &service, full);
     }
     if trusted_requested {
         let service = must(
-            ZanzibarService::load_snapshot(&path, trusted_fast_load_options()),
+            ZanzibarEngine::load_snapshot(&path, trusted_fast_load_options()),
             "failed to trusted-load snapshot for loaded-query benchmarks",
         );
         bench_loaded_query_set(criterion, filters, &service, trusted);
@@ -230,7 +230,7 @@ fn loaded_query_requested(names: LoadedQueryBenchNames, filters: &[String]) -> b
 fn bench_loaded_query_set(
     criterion: &mut Criterion,
     filters: &[String],
-    service: &ZanzibarService,
+    service: &ZanzibarEngine,
     names: LoadedQueryBenchNames,
 ) {
     if !loaded_query_requested(names, filters) {
@@ -251,7 +251,7 @@ fn bench_loaded_query_set(
         criterion.bench_function(names.direct, |bencher| {
             bencher.iter(|| {
                 black_box(must(
-                    service.check(
+                    service.check_relation(
                         black_box(&direct_doc),
                         black_box(&can_view),
                         black_box(&target_user),
@@ -266,7 +266,7 @@ fn bench_loaded_query_set(
         criterion.bench_function(names.inherited, |bencher| {
             bencher.iter(|| {
                 black_box(must(
-                    service.check(
+                    service.check_relation(
                         black_box(&inherited_doc),
                         black_box(&can_view),
                         black_box(&target_user),
@@ -337,15 +337,17 @@ fn trusted_fast_load_options() -> SnapshotLoadOptions {
     }
 }
 
-fn build_service_with_relationships(rules: usize) -> ZanzibarService {
-    let mut service = configured_service();
+fn build_service_with_relationships(rules: usize) -> ZanzibarEngine {
+    let service = configured_service();
     let relationships = generated_relationships(rules);
-    apply_relationships(&mut service, &relationships);
+    apply_relationships(&service, &relationships);
     service
 }
 
-fn configured_service() -> ZanzibarService {
-    let mut service = ZanzibarService::new().with_evaluation_limits(evaluation_limits());
+fn configured_service() -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(evaluation_limits())
+        .build();
     must(service.add_dsl(org_schema()), "failed to apply org schema");
     service
 }
@@ -368,7 +370,7 @@ fn generated_relationships(rules: usize) -> Vec<Relationship> {
     relationships
 }
 
-fn apply_relationships(service: &mut ZanzibarService, relationships: &[Relationship]) {
+fn apply_relationships(service: &ZanzibarEngine, relationships: &[Relationship]) {
     let mut batch = Vec::with_capacity(MUTATION_BATCH_LIMIT);
     for relationship in relationships {
         batch.push(RelationshipMutation::Touch(relationship.clone()));
@@ -379,13 +381,13 @@ fn apply_relationships(service: &mut ZanzibarService, relationships: &[Relations
     flush_relationships(service, &mut batch);
 }
 
-fn flush_relationships(service: &mut ZanzibarService, batch: &mut Vec<RelationshipMutation>) {
+fn flush_relationships(service: &ZanzibarEngine, batch: &mut Vec<RelationshipMutation>) {
     if batch.is_empty() {
         return;
     }
     let mutations = std::mem::take(batch);
     must(
-        service.apply_relationship_mutations(mutations, []),
+        service.write_relationships_with_preconditions(mutations, []),
         "failed to apply relationship batch",
     );
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,6 @@
 # Examples
 
 Examples of using the crate.
+
+- `cargo run --example file_permissions`: legacy service facade with a file/folder hierarchy.
+- `cargo run --example collaboration_workspace`: public engine API in a realistic workspace/project/document flow, including relationship updates, permission lookups, reviewable policy export/import, and zstd snapshot save/load.

--- a/examples/collaboration_workspace.rs
+++ b/examples/collaboration_workspace.rs
@@ -1,0 +1,421 @@
+//! Example: collaborative workspace authorization with import/export.
+//!
+//! The scenario models a small workspace where users inherit access from a workspace into a project
+//! and then into documents. It also demonstrates guarded updates, permission lookup APIs,
+//! reviewable policy export/import, and zstd-compressed snapshot save/load.
+
+use std::{
+    error::Error,
+    fs, io,
+    path::{Path, PathBuf},
+    process,
+};
+
+use simple_zanzibar::{
+    SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
+    model::{
+        CheckRequest, LookupObjectPermissionsRequest, LookupPermissionsRequest,
+        LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, User,
+    },
+    relationship::RelationshipMutation,
+    revision::{Consistency, ConsistencyToken},
+    schema::SchemaSource,
+};
+
+const SCHEMA: &str = r#"
+namespace workspace {
+    relation owner {}
+    relation member {}
+    relation auditor {}
+
+    relation admin {
+        rewrite computed_userset(relation: "owner")
+    }
+
+    relation viewer {
+        rewrite union(
+            computed_userset(relation: "owner"),
+            computed_userset(relation: "member"),
+            computed_userset(relation: "auditor")
+        )
+    }
+}
+
+namespace project {
+    relation parent {}
+    relation owner {}
+    relation editor {}
+    relation viewer {}
+    relation banned {}
+
+    relation can_view {
+        rewrite exclusion(
+            union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "editor"),
+                computed_userset(relation: "viewer"),
+                tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
+            ),
+            computed_userset(relation: "banned")
+        )
+    }
+
+    relation can_edit {
+        rewrite exclusion(
+            union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "editor")
+            ),
+            computed_userset(relation: "banned")
+        )
+    }
+
+    relation can_admin {
+        rewrite computed_userset(relation: "owner")
+    }
+}
+
+namespace doc {
+    relation parent {}
+    relation owner {}
+    relation editor {}
+    relation viewer {}
+    relation banned {}
+
+    relation can_view {
+        rewrite exclusion(
+            union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "editor"),
+                computed_userset(relation: "viewer"),
+                tuple_to_userset(tupleset: "parent", computed_userset: "can_view")
+            ),
+            computed_userset(relation: "banned")
+        )
+    }
+
+    relation can_edit {
+        rewrite exclusion(
+            union(
+                computed_userset(relation: "owner"),
+                computed_userset(relation: "editor"),
+                tuple_to_userset(tupleset: "parent", computed_userset: "can_edit")
+            ),
+            computed_userset(relation: "banned")
+        )
+    }
+
+    relation can_share {
+        rewrite union(
+            computed_userset(relation: "owner"),
+            computed_userset(relation: "editor")
+        )
+    }
+}
+"#;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let paths = ExamplePaths::new();
+    remove_directory_if_exists(&paths.root)?;
+    fs::create_dir_all(&paths.root)?;
+
+    let engine = ZanzibarEngine::builder().build();
+    engine.apply_schema(SchemaSource {
+        name: Some("collaboration"),
+        text: SCHEMA,
+    })?;
+
+    let initial_token = grant_initial_relationships(&engine)?;
+    show_exact_consistency_check(&engine, initial_token)?;
+    show_initial_permissions(&engine)?;
+    assert_initial_access(&engine)?;
+
+    change_project_membership(&engine)?;
+    assert_updated_access(&engine)?;
+    show_updated_permissions(&engine)?;
+
+    demonstrate_schema_guardrail(&engine)?;
+    export_and_reload_policy(&engine, &paths.policy_dir)?;
+    save_and_load_zstd_snapshot(&engine, &paths.snapshot)?;
+
+    remove_directory_if_exists(&paths.root)?;
+    println!("\ncollaboration workspace example completed");
+    Ok(())
+}
+
+fn grant_initial_relationships(
+    engine: &ZanzibarEngine,
+) -> Result<ConsistencyToken, Box<dyn Error>> {
+    let mutations = [
+        "workspace:platform#owner@user:alice",
+        "workspace:platform#member@user:bob",
+        "workspace:platform#auditor@user:eve",
+        "project:launch#parent@workspace:platform#viewer",
+        "project:launch#owner@user:alice",
+        "project:launch#editor@user:bob",
+        "project:launch#viewer@user:carol",
+        "doc:launch_plan#parent@project:launch#can_view",
+        "doc:launch_plan#viewer@user:dave",
+        "doc:budget#parent@project:launch#can_view",
+        "doc:budget#banned@user:eve",
+    ]
+    .into_iter()
+    .map(RelationshipMutation::touch)
+    .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(engine.write_relationships(mutations)?)
+}
+
+fn show_exact_consistency_check(
+    engine: &ZanzibarEngine,
+    token: ConsistencyToken,
+) -> Result<(), Box<dyn Error>> {
+    let allowed = engine
+        .check(CheckRequest::new(
+            doc("launch_plan"),
+            relation("can_view"),
+            user("alice"),
+            Consistency::Exact(token),
+        ))?
+        .allowed;
+    println!("Alice can view the launch plan at the initial revision: {allowed}");
+    Ok(())
+}
+
+fn show_initial_permissions(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    println!("\ninitial access checks");
+    print_check(engine, "Alice", "can_edit", "launch_plan")?;
+    print_check(engine, "Bob", "can_edit", "launch_plan")?;
+    print_check(engine, "Carol", "can_edit", "launch_plan")?;
+    print_check(engine, "Eve", "can_view", "budget")?;
+
+    let carol_permissions = engine.lookup_permissions(LookupPermissionsRequest::new(
+        user("carol"),
+        doc("launch_plan"),
+        Consistency::Latest,
+    ))?;
+    println!(
+        "Carol relations/permissions on launch_plan: {}",
+        relation_names(&carol_permissions.permissions).join(", ")
+    );
+
+    let editable_projects = engine.lookup_resources(LookupResourcesRequest::new(
+        user("bob"),
+        relation("can_edit"),
+        "project",
+    ))?;
+    println!(
+        "Projects Bob can edit: {}",
+        object_names(&editable_projects.resources).join(", ")
+    );
+
+    let project_editors = engine.lookup_subjects(LookupSubjectsRequest::new(
+        project("launch"),
+        relation("can_edit"),
+        "user",
+    ))?;
+    println!(
+        "Users who can edit the launch project: {}",
+        user_names(&project_editors.subjects).join(", ")
+    );
+
+    Ok(())
+}
+
+fn assert_initial_access(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    assert!(can(engine, doc("launch_plan"), "can_edit", user("alice"))?);
+    assert!(can(engine, doc("launch_plan"), "can_edit", user("bob"))?);
+    assert!(!can(engine, doc("launch_plan"), "can_edit", user("carol"))?);
+    assert!(can(engine, doc("launch_plan"), "can_view", user("eve"))?);
+    assert!(!can(engine, doc("budget"), "can_view", user("eve"))?);
+    Ok(())
+}
+
+fn change_project_membership(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    engine.touch_relationship("project:launch#editor@user:carol")?;
+    engine.delete_relationship("project:launch#editor@user:bob")?;
+    println!("\nupdated project membership: Carol is now editor, Bob is no longer editor");
+    Ok(())
+}
+
+fn assert_updated_access(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    assert!(!can(engine, doc("launch_plan"), "can_edit", user("bob"))?);
+    assert!(can(engine, doc("launch_plan"), "can_view", user("bob"))?);
+    assert!(can(engine, doc("launch_plan"), "can_edit", user("carol"))?);
+    assert!(!can(engine, doc("budget"), "can_view", user("eve"))?);
+    Ok(())
+}
+
+fn show_updated_permissions(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    let carol_permissions = engine.lookup_permissions(LookupPermissionsRequest::new(
+        user("carol"),
+        doc("launch_plan"),
+        Consistency::Latest,
+    ))?;
+    println!(
+        "Carol relations/permissions after promotion: {}",
+        relation_names(&carol_permissions.permissions).join(", ")
+    );
+
+    let budget_permissions = engine.lookup_object_permissions(
+        LookupObjectPermissionsRequest::new(doc("budget"), "user", Consistency::Latest),
+    )?;
+    println!("Budget document relation/permission groups:");
+    for permission in budget_permissions.permissions {
+        println!(
+            "  {}: {}",
+            permission.permission.0,
+            user_names(&permission.subjects).join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn demonstrate_schema_guardrail(engine: &ZanzibarEngine) -> Result<(), Box<dyn Error>> {
+    match engine.delete_relation("doc", "viewer") {
+        Ok(_) => Err(Box::new(io::Error::other(
+            "schema guardrail unexpectedly allowed deleting a live relation",
+        ))),
+        Err(error) => {
+            println!("\nschema guardrail rejected deleting doc.viewer: {error}");
+            assert!(can(engine, doc("launch_plan"), "can_view", user("dave"))?);
+            Ok(())
+        }
+    }
+}
+
+fn export_and_reload_policy(
+    engine: &ZanzibarEngine,
+    directory: &Path,
+) -> Result<(), Box<dyn Error>> {
+    engine.export_policy_files(directory)?;
+    let policy = engine.export_policy_text()?;
+    println!(
+        "\nexported reviewable policy: {} schema bytes, {} relationship files",
+        policy.schema.len(),
+        policy.relationship_files.len()
+    );
+    for file in &policy.relationship_files {
+        println!("  {} ({} bytes)", file.path, file.contents.len());
+    }
+
+    let imported = ZanzibarEngine::from_policy_text(&policy)?;
+    assert_updated_access(&imported)?;
+    Ok(())
+}
+
+fn save_and_load_zstd_snapshot(
+    engine: &ZanzibarEngine,
+    snapshot: &Path,
+) -> Result<(), Box<dyn Error>> {
+    engine.save_snapshot(snapshot, SnapshotSaveOptions::zstd())?;
+    let size = fs::metadata(snapshot)?.len();
+    let loaded = ZanzibarEngine::load_snapshot(snapshot, SnapshotLoadOptions::zstd())?;
+    assert_updated_access(&loaded)?;
+    println!("saved and loaded zstd snapshot: {size} bytes");
+    Ok(())
+}
+
+fn print_check(
+    engine: &ZanzibarEngine,
+    user_id: &str,
+    permission: &str,
+    doc_id: &str,
+) -> Result<(), Box<dyn Error>> {
+    let allowed = can(
+        engine,
+        doc(doc_id),
+        permission,
+        user(&user_id.to_ascii_lowercase()),
+    )?;
+    println!("  {user_id} {permission} {doc_id}: {allowed}");
+    Ok(())
+}
+
+fn can(
+    engine: &ZanzibarEngine,
+    object: Object,
+    permission: &str,
+    subject: User,
+) -> Result<bool, Box<dyn Error>> {
+    Ok(engine
+        .check(CheckRequest::new(
+            object,
+            relation(permission),
+            subject,
+            Consistency::Latest,
+        ))?
+        .allowed)
+}
+
+fn project(id: &str) -> Object {
+    Object::new("project", id)
+}
+
+fn doc(id: &str) -> Object {
+    Object::new("doc", id)
+}
+
+fn relation(name: &str) -> Relation {
+    Relation::new(name)
+}
+
+fn user(id: &str) -> User {
+    User::user_id(id)
+}
+
+fn relation_names(relations: &[Relation]) -> Vec<String> {
+    relations
+        .iter()
+        .map(|relation| relation.0.clone())
+        .collect()
+}
+
+fn object_names(objects: &[Object]) -> Vec<String> {
+    objects
+        .iter()
+        .map(|object| format!("{}:{}", object.namespace, object.id))
+        .collect()
+}
+
+fn user_names(users: &[User]) -> Vec<String> {
+    users.iter().map(user_name).collect()
+}
+
+fn user_name(user: &User) -> String {
+    match user {
+        User::UserId(id) => format!("user:{id}"),
+        User::Userset(object, relation) => {
+            format!("{}:{}#{}", object.namespace, object.id, relation.0)
+        }
+    }
+}
+
+fn remove_directory_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[derive(Debug)]
+struct ExamplePaths {
+    root: PathBuf,
+    policy_dir: PathBuf,
+    snapshot: PathBuf,
+}
+
+impl ExamplePaths {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "simple-zanzibar-collaboration-example-{}",
+            process::id()
+        ));
+        Self {
+            policy_dir: root.join("policy"),
+            snapshot: root.join("workspace.szsnap.zst"),
+            root,
+        }
+    }
+}

--- a/examples/file_permissions.rs
+++ b/examples/file_permissions.rs
@@ -4,7 +4,7 @@
 //! to implement a file permissions system with hierarchical access control.
 
 use simple_zanzibar::{
-    ZanzibarService,
+    ZanzibarEngine,
     model::{Object, Relation, RelationTuple, User},
 };
 
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Simplified Zanzibar File Permissions Example");
     println!("=============================================\n");
 
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Define the policy using DSL
     let policy_dsl = r#"
@@ -126,55 +126,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Alice's permissions:");
     println!(
         "  Can view root folder: {}",
-        service.check(&root_folder, &viewer_rel, &alice)?
+        service.check_relation(&root_folder, &viewer_rel, &alice)?
     );
     println!(
         "  Can view docs folder: {}",
-        service.check(&docs_folder, &viewer_rel, &alice)?
+        service.check_relation(&docs_folder, &viewer_rel, &alice)?
     );
     println!(
         "  Can view README file: {}",
-        service.check(&readme_file, &viewer_rel, &alice)?
+        service.check_relation(&readme_file, &viewer_rel, &alice)?
     );
     println!(
         "  Can edit README file: {}",
-        service.check(&readme_file, &editor_rel, &alice)?
+        service.check_relation(&readme_file, &editor_rel, &alice)?
     );
     println!(
         "  Can view secret file: {}",
-        service.check(&secret_file, &viewer_rel, &alice)?
+        service.check_relation(&secret_file, &viewer_rel, &alice)?
     );
 
     println!("\nBob's permissions:");
     println!(
         "  Can view root folder: {}",
-        service.check(&root_folder, &viewer_rel, &bob)?
+        service.check_relation(&root_folder, &viewer_rel, &bob)?
     );
     println!(
         "  Can view README file: {}",
-        service.check(&readme_file, &viewer_rel, &bob)?
+        service.check_relation(&readme_file, &viewer_rel, &bob)?
     );
     println!(
         "  Can edit README file: {}",
-        service.check(&readme_file, &editor_rel, &bob)?
+        service.check_relation(&readme_file, &editor_rel, &bob)?
     );
     println!(
         "  Can view secret file: {}",
-        service.check(&secret_file, &viewer_rel, &bob)?
+        service.check_relation(&secret_file, &viewer_rel, &bob)?
     );
 
     println!("\nCharlie's permissions:");
     println!(
         "  Can view root folder: {}",
-        service.check(&root_folder, &viewer_rel, &charlie)?
+        service.check_relation(&root_folder, &viewer_rel, &charlie)?
     );
     println!(
         "  Can view README file: {}",
-        service.check(&readme_file, &viewer_rel, &charlie)?
+        service.check_relation(&readme_file, &viewer_rel, &charlie)?
     );
     println!(
         "  Can view secret file: {}",
-        service.check(&secret_file, &viewer_rel, &charlie)?
+        service.check_relation(&secret_file, &viewer_rel, &charlie)?
     );
 
     println!("\nTesting dynamic permission changes...\n");
@@ -190,11 +190,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Bob's updated permissions:");
     println!(
         "  Can view root folder: {}",
-        service.check(&root_folder, &viewer_rel, &bob)?
+        service.check_relation(&root_folder, &viewer_rel, &bob)?
     );
     println!(
         "  Can view docs folder: {}",
-        service.check(&docs_folder, &viewer_rel, &bob)?
+        service.check_relation(&docs_folder, &viewer_rel, &bob)?
     );
 
     // Revoke Bob's editor access to README
@@ -208,16 +208,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Bob's permissions after revocation:");
     println!(
         "  Can view README file: {}",
-        service.check(&readme_file, &viewer_rel, &bob)?
+        service.check_relation(&readme_file, &viewer_rel, &bob)?
     );
     println!(
         "  Can edit README file: {}",
-        service.check(&readme_file, &editor_rel, &bob)?
+        service.check_relation(&readme_file, &editor_rel, &bob)?
     );
 
     println!("\nTesting expand functionality...\n");
 
-    let expanded = service.expand(&readme_file, &viewer_rel)?;
+    let expanded = service.expand_relation(&readme_file, &viewer_rel)?;
     println!("Users who can view README file: {expanded:?}");
 
     println!("\nExample completed successfully!");

--- a/specs/00-local-engine-prd.md
+++ b/specs/00-local-engine-prd.md
@@ -40,7 +40,7 @@ The public API remains ergonomic, but internally every request flows through val
 | G2 | Make reads fast by design. | Direct checks over 100k relationships avoid full-store scans and use resource/subject indexes. Benchmark gates are defined in [71-performance-budgets-design.md](./71-performance-budgets-design.md). |
 | G3 | Add deterministic local consistency. | Every schema or relationship write returns a token; exact-token checks read a stable snapshot. |
 | G4 | Support core Zanzibar APIs as a library. | `check`, `expand`, `lookup_resources`, and `lookup_subjects` are backed by one engine and share validation, snapshots, and membership algebra. |
-| G5 | Preserve a compatibility path. | Existing `ZanzibarService` examples and tests either keep working or fail with documented migration errors. |
+| G5 | Expose one coherent public runtime. | `ZanzibarEngine` is the only public engine facade; legacy mutable facade is removed before API stabilization. |
 | G6 | Meet project engineering policy. | `cargo build`, `cargo test`, `cargo +nightly fmt --check`, `cargo clippy -- -D warnings -W clippy::pedantic`, `cargo audit`, and `cargo deny check` pass before each implementation phase closes. |
 | G7 | Keep large local authorization datasets memory-efficient. | The 1M-rule org authorization benchmark has steady-state max RSS <= 400 MiB after the compact relationship store lands. |
 
@@ -72,7 +72,7 @@ Anti-personas:
 
 ## 6. Success Metrics
 
-- All legacy tests pass through the v2 compatibility facade.
+- Public behavior tests pass through `ZanzibarEngine` without a legacy mutable facade.
 - At least 20 schema-validation negative tests reject invalid computed-userset, tuple-to-userset, and duplicate relation definitions.
 - At least 10 property tests cover relationship-store index consistency.
 - Direct-check benchmark demonstrates indexed lookup rather than scan behavior at 10k, 100k, and 1M relationship scales.

--- a/specs/15-public-api-design.md
+++ b/specs/15-public-api-design.md
@@ -6,7 +6,9 @@ Depends on: [14-evaluation-engine-design.md](./14-evaluation-engine-design.md)
 
 ## 1. Purpose
 
-This spec defines the crate-facing API and migration shape. The new engine is strict and typed, while the existing `ZanzibarService` facade remains as a compatibility layer until the v2 API is proven by tests and examples.
+This spec defines the crate-facing API and migration shape. The new engine is strict and typed.
+[20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md) supersedes the
+early compatibility plan and removes the legacy mutable facade from the public API before stabilization.
 
 ## 2. Public Surface
 
@@ -39,20 +41,10 @@ Request builders are provided for multi-field requests. Per AGENTS.md, `typed-bu
 
 ## 3. Compatibility Facade
 
-`ZanzibarService` stays available for M0:
-
-```rust
-impl ZanzibarService {
-    pub fn new() -> Self;
-    pub fn add_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError>;
-    pub fn write_tuple(&mut self, tuple: RelationTuple) -> Result<(), ZanzibarError>;
-    pub fn delete_tuple(&mut self, tuple: &RelationTuple) -> Result<(), ZanzibarError>;
-    pub fn check(...) -> Result<bool, ZanzibarError>;
-    pub fn expand(...) -> Result<ExpandedUserset, ZanzibarError>;
-}
-```
-
-Internally it delegates to `ZanzibarEngine`. Legacy model structs are converted into v2 domain types at the boundary. When legacy values are invalid under v2 validation, the facade returns a migration error with the invalid field name.
+The early M0 compatibility facade is retired by
+[20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md). Public examples,
+tests, and benchmarks use `ZanzibarEngine` directly. Legacy model structs that remain public for
+request DTOs are converted into validated domain types at the engine boundary.
 
 ## 4. Error Model
 
@@ -88,7 +80,7 @@ Every public API gets a doc-tested example:
 - Type Design & API: explicit return types, builders for request structs with more than five fields.
 - Safety & Security: string-based convenience constructors validate before engine access.
 - Serialization: optional serde feature for request/response DTOs, camelCase, deny unknown fields.
-- Testing: examples are doctests; compatibility facade has integration tests.
+- Testing: examples are doctests; public behavior tests target `ZanzibarEngine` directly.
 - Logging & Observability: public API starts tracing spans when `tracing` feature is enabled.
 - Performance: string convenience APIs are not used inside hot evaluator loops.
 - Documentation: public API docs are complete before release.
@@ -98,3 +90,4 @@ Every public API gets a doc-tested example:
 - <- Depends on: [14-evaluation-engine-design.md](./14-evaluation-engine-design.md)
 - -> Consumed by: [60-crates-features-design.md](./60-crates-features-design.md), [72-testing-verification-plan.md](./72-testing-verification-plan.md)
 - Related research: [../docs/research/study-spicedb.md § Request Paths](../docs/research/study-spicedb.md#request-paths)
+- Superseded runtime details: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md)

--- a/specs/16-compact-relationship-store-design.md
+++ b/specs/16-compact-relationship-store-design.md
@@ -23,7 +23,7 @@ The primary cause is not the Zanzibar model. It is duplicated ownership and poin
 - `IndexedRelationshipStore` stores owned `Relationship` values in both `rows` and `uniqueness`.
 - Every index key clones string-backed domain types.
 - Posting lists use `BTreeSet<usize>`, allocating tree nodes for row ids.
-- `publish_snapshot` stores one relationship copy in `ZanzibarService` and another clone inside `PublishedSnapshot`.
+- `publish_snapshot` stores one relationship copy in the writer-owned store and another clone inside `PublishedSnapshot`.
 - The compatibility `InMemoryTupleStore` can retain another full legacy tuple representation.
 
 ## 2. Goals
@@ -32,7 +32,7 @@ The primary cause is not the Zanzibar model. It is duplicated ownership and poin
 | --- | --- | --- |
 | G1 | Reduce steady-state RSS by one order of magnitude for large org datasets. | `org_authorization/1m_rules/check_direct_group_viewer` max RSS <= 400 MiB on the reference machine, excluding future Criterion variance. |
 | G2 | Preserve current read latency. | Direct check p95 remains <= 10 us over 1M relationships; inherited check p95 remains <= 25 us. |
-| G3 | Preserve public API compatibility. | Existing `Relationship`, `RelationshipFilter`, `SubjectFilter`, `ZanzibarService`, consistency, check, expand, and lookup tests keep passing. |
+| G3 | Preserve public API compatibility. | Existing `Relationship`, `RelationshipFilter`, `SubjectFilter`, `ZanzibarEngine`, consistency, check, expand, and lookup tests keep passing. |
 | G4 | Keep exact snapshot semantics. | Published snapshots remain immutable; exact-token reads never observe later writes. |
 | G5 | Keep implementation simple enough to review. | Start with std collections, compact ids, and `Vec<RowId>` postings; defer compressed bitmaps until benchmarks prove a need. |
 
@@ -47,7 +47,7 @@ The primary cause is not the Zanzibar model. It is duplicated ownership and poin
 ## 4. Current Memory Shape
 
 ```text
-ZanzibarService
+WriterState
   |
   +-- relationships: IndexedRelationshipStore
   |     |
@@ -73,7 +73,7 @@ The same logical relationship is represented as multiple independent allocations
 ## 5. Target Architecture
 
 ```text
-ZanzibarService
+WriterState
   |
   +-- current_snapshot: ArcSwap<PublishedSnapshot>
   |
@@ -266,7 +266,7 @@ self.current_snapshot.store(Arc<PublishedSnapshot>)
 self.snapshot_history.push_back(Arc<PublishedSnapshot>)
 ```
 
-`ZanzibarService` should not own a separate relationship store outside the current `PublishedSnapshot`. When a write starts, it loads the current snapshot and builds the next compact snapshot from it. For M6, copying compact rows/postings during a write is acceptable because the steady-state memory target is the release gate; a later persistent delta store can optimize write amplification if benchmark evidence requires it.
+The writer state should not own a separate relationship store outside the current `PublishedSnapshot`. When a write starts, it loads the current snapshot and builds the next compact snapshot from it. For M6, copying compact rows/postings during a write is acceptable because the steady-state memory target is the release gate; a later persistent delta store can optimize write amplification if benchmark evidence requires it.
 
 Compatibility store policy:
 

--- a/specs/17-compact-snapshot-format-design.md
+++ b/specs/17-compact-snapshot-format-design.md
@@ -282,7 +282,7 @@ pub enum SnapshotIntegrityMode {
     External,
 }
 
-impl ZanzibarService {
+impl ZanzibarEngine {
     pub fn save_snapshot(
         &self,
         path: impl AsRef<Path>,
@@ -308,7 +308,7 @@ impl IndexedRelationshipStore {
 }
 ```
 
-The public API returns a fully usable `ZanzibarService` with a current `PublishedSnapshot`. The loaded service uses the artifact revision and datastore id policy defined below.
+The public API returns a fully usable `ZanzibarEngine` with a current `PublishedSnapshot`. The loaded engine uses the artifact revision and datastore id policy defined below.
 
 ## 8. Revision and Consistency Semantics
 
@@ -372,7 +372,7 @@ load_snapshot(path)
   +-- copy symbol bytes, symbol table, and rows into store vectors
   +-- validate index key/range sections
   +-- build runtime sorted-array indexes
-  +-- publish one PublishedSnapshot into ZanzibarService
+  +-- publish one PublishedSnapshot into ZanzibarEngine state
 ```
 
 The first implementation may still copy the file sections into owned vectors. The important property is that it avoids per-relationship domain object allocation and avoids re-interning strings from text.
@@ -467,7 +467,7 @@ Required tests:
 - loaded snapshot check/expand/lookup equivalence against build-from-relationships snapshot
 - exact consistency behavior after loading and after a subsequent write
 - property test: random compact stores save/load to equivalent query results
-- compatibility test: loaded service public APIs match normal `ZanzibarService` APIs
+- compatibility test: loaded engine public APIs match normal `ZanzibarEngine` APIs
 
 Slow 1M load/save tests are benchmark/ignored tests, not regular unit tests.
 
@@ -509,7 +509,7 @@ loaded query budgets pass.
 
 ### M7.5 - Public API and Docs
 
-- Add `ZanzibarService::save_snapshot` and `ZanzibarService::load_snapshot`.
+- Add `ZanzibarEngine::save_snapshot` and `ZanzibarEngine::load_snapshot`.
 - Document token/datastore semantics.
 - Add examples and update verification docs.
 

--- a/specs/19-public-api-completeness-design.md
+++ b/specs/19-public-api-completeness-design.md
@@ -98,27 +98,16 @@ pub struct PolicyTextFile {
     pub contents: String,
 }
 
-impl ZanzibarService {
-    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, ZanzibarError>;
-    pub fn apply_policy_text(&mut self, policy: &PolicyText) -> Result<ConsistencyToken, ZanzibarError>;
-    pub fn export_policy_text(&self) -> Result<PolicyText, ZanzibarError>;
+impl ZanzibarEngine {
+    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, EngineError>;
+    pub fn apply_policy_text(&self, policy: &PolicyText) -> Result<ConsistencyToken, EngineError>;
+    pub fn export_policy_text(&self) -> Result<PolicyText, EngineError>;
     pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError>;
     pub fn save_snapshot_from_policy_text(
         path: impl AsRef<Path>,
         policy: &PolicyText,
         options: SnapshotSaveOptions,
     ) -> Result<(), PolicyIoError>;
-}
-```
-
-`ZanzibarEngine` exposes the same operations where engine locking is relevant:
-
-```rust
-impl ZanzibarEngine {
-    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, EngineError>;
-    pub fn apply_policy_text(&self, policy: &PolicyText) -> Result<ConsistencyToken, EngineError>;
-    pub fn export_policy_text(&self) -> Result<PolicyText, EngineError>;
-    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError>;
 }
 ```
 
@@ -144,17 +133,6 @@ Existing APIs:
 New APIs:
 
 ```rust
-impl ZanzibarService {
-    pub fn replace_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError>;
-    pub fn replace_dsl_with_token(&mut self, dsl: &str) -> Result<ConsistencyToken, ZanzibarError>;
-    pub fn delete_namespace(&mut self, namespace: &str) -> Result<ConsistencyToken, ZanzibarError>;
-    pub fn delete_relation(
-        &mut self,
-        namespace: &str,
-        relation: &str,
-    ) -> Result<ConsistencyToken, ZanzibarError>;
-}
-
 impl ZanzibarEngine {
     pub fn replace_schema(&self, source: SchemaSource<'_>) -> Result<ConsistencyToken, EngineError>;
     pub fn delete_namespace(&self, namespace: &str) -> Result<ConsistencyToken, EngineError>;
@@ -256,7 +234,7 @@ and startup tradeoff visibility.
 
 ## 7. Testing Requirements
 
-- zstd snapshot save/load equivalence through `ZanzibarService` and `ZanzibarEngine`.
+- zstd snapshot save/load equivalence through `ZanzibarEngine`.
 - zstd decompression size cap rejects oversized decompressed output.
 - `PolicyText` export/import round trip preserves check, expand, lookup, and permission enumeration.
 - `export_policy_files` creates deterministic `schema.zed` plus grouped sorted relationship files.

--- a/specs/19-public-api-completeness-design.md
+++ b/specs/19-public-api-completeness-design.md
@@ -1,0 +1,292 @@
+# 19 - Public API Completeness Design
+
+Status: draft v1
+Owner: Simple Zanzibar
+Last updated: 2026-05-23
+Depends on: [15](./15-public-api-design.md), [17](./17-compact-snapshot-format-design.md), [18](./18-trusted-fast-snapshot-load-design.md)
+
+## 1. Purpose
+
+The engine can already load uncompressed compact snapshots, mutate relationships, and answer core
+Zanzibar queries. The remaining product gap is the boundary around those capabilities: callers need
+direct zstd snapshot support, explicit policy import/export APIs for reviewable text artifacts,
+schema replacement/deletion APIs, and audit-style query helpers that avoid forcing every user to
+hand-roll schema enumeration.
+
+This spec completes the crate-facing API without changing the internal `.szsnap` v2 payload layout.
+Compression is an outer transport wrapper; canonical policy text is a review artifact; permission
+enumeration is implemented by composing schema relation enumeration with the existing evaluator.
+
+## 2. Goals
+
+| # | Goal | Measure |
+| --- | --- | --- |
+| G1 | Load and save both raw `.szsnap` and zstd-compressed snapshot files. | Public API supports `SnapshotCompression::{None, Zstd}` for save and load; zstd round trips pass equivalence tests. |
+| G2 | Import policy from raw text and export policy to reviewable text. | `PolicyText` can rebuild an equivalent service; exported files are deterministic, sorted, and grouped by resource namespace. |
+| G3 | Support add, replace, and delete policy operations. | Public schema APIs can merge DSL, replace DSL, delete a namespace, and delete one relation while revalidating existing relationships. |
+| G4 | Add audit-style Zanzibar helpers. | Public APIs answer "what permissions does this subject have on this object" and "who has which permissions on this object" without callers enumerating schema relations manually. |
+| G5 | Preserve hot-path performance. | Existing `check`, lookup, full snapshot load, and trusted fast-load benchmark gates remain valid; zstd overhead is measured separately. |
+| G6 | Keep safety and review ergonomics. | No `unsafe`, no production `unwrap`/`expect`, bounded decompression, typed errors, deterministic output ordering. |
+
+## 3. Non-Goals
+
+- No change to the `.szsnap` v2 internal section layout.
+- No mmap or zero-copy compressed loading.
+- No cryptographic signing implementation. External integrity remains a caller-supplied boundary.
+- No unbounded global "list every subject and every permission in the datastore" API.
+- No semantic distinction between "relation" and "permission" in the first enumeration API; every schema relation can be checked.
+- No incremental rsync-like delta protocol. The rsync metaphor applies to API shape: export/import should make review and distribution cheap by canonicalizing data, while the binary snapshot remains the fastest whole-state artifact.
+
+## 4. API Additions
+
+### 4.1 Snapshot Compression
+
+```rust
+pub enum SnapshotCompression {
+    None,
+    Zstd,
+}
+
+pub struct SnapshotSaveOptions {
+    pub compression: SnapshotCompression,
+    pub zstd_level: i32,
+    pub include_indexes: bool,
+}
+
+pub struct SnapshotLoadOptions {
+    pub compression: SnapshotCompression,
+    pub profile: SnapshotLoadProfile,
+    pub validation: SnapshotValidationMode,
+    pub integrity: SnapshotIntegrityMode,
+    pub max_file_bytes: NonZeroU64,
+}
+```
+
+Rules:
+
+- `SnapshotCompression::None` writes and reads the raw `.szsnap` v2 bytes.
+- `SnapshotCompression::Zstd` writes and reads a single zstd frame whose decompressed payload is the
+  same raw `.szsnap` v2 bytes.
+- Save validates `zstd_level` against the zstd crate's accepted compression-level range.
+- Load applies `max_file_bytes` to both the compressed file size and decompressed output size.
+- `SnapshotIntegrityMode::Checksum` verifies the inner `.szsnap` footer after decompression.
+- `SnapshotIntegrityMode::External` continues to mean the caller has already verified artifact byte
+  identity. For compressed snapshots, the external proof is assumed to bind the compressed bytes.
+
+```text
+raw .szsnap load
+  file bytes ───────────────▶ .szsnap v2 parser ─▶ PublishedSnapshot
+
+zstd .szsnap.zst load
+  compressed bytes ─▶ bounded zstd decode ─▶ .szsnap v2 parser ─▶ PublishedSnapshot
+```
+
+Compression is intentionally outside the trusted fast-load budget. The recommended deployment path
+for the fastest cold start remains: verify/download zstd artifact, decompress once into a
+content-addressed local cache, then load cached raw `.szsnap` with `TrustedFastLoad + External`.
+
+### 4.2 Policy Text Import/Export
+
+```rust
+pub struct PolicyText {
+    pub schema: String,
+    pub relationship_files: Vec<PolicyTextFile>,
+}
+
+pub struct PolicyTextFile {
+    pub path: String,
+    pub contents: String,
+}
+
+impl ZanzibarService {
+    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, ZanzibarError>;
+    pub fn apply_policy_text(&mut self, policy: &PolicyText) -> Result<ConsistencyToken, ZanzibarError>;
+    pub fn export_policy_text(&self) -> Result<PolicyText, ZanzibarError>;
+    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError>;
+    pub fn save_snapshot_from_policy_text(
+        path: impl AsRef<Path>,
+        policy: &PolicyText,
+        options: SnapshotSaveOptions,
+    ) -> Result<(), PolicyIoError>;
+}
+```
+
+`ZanzibarEngine` exposes the same operations where engine locking is relevant:
+
+```rust
+impl ZanzibarEngine {
+    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, EngineError>;
+    pub fn apply_policy_text(&self, policy: &PolicyText) -> Result<ConsistencyToken, EngineError>;
+    pub fn export_policy_text(&self) -> Result<PolicyText, EngineError>;
+    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError>;
+}
+```
+
+Export rules:
+
+- `schema.zed` contains canonical DSL sorted by namespace name, then relation name.
+- Relationships are grouped by resource object type under `relationships/<type>.zedtuples`.
+- Relationship lines are sorted by their canonical string form.
+- Exported relationship files end with a trailing newline when non-empty.
+- Empty relationship groups are omitted.
+- Relationship import accepts blank lines plus full-line `#` and `//` comments.
+
+The output is optimized for review and diff stability, not load speed. Snapshot artifacts remain the
+fast runtime loading format.
+
+### 4.3 Policy Mutation APIs
+
+Existing APIs:
+
+- `add_dsl` / `add_dsl_with_token`: merge or overwrite namespaces from DSL.
+- `add_config` / `add_config_with_token`: merge or overwrite one namespace config.
+
+New APIs:
+
+```rust
+impl ZanzibarService {
+    pub fn replace_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError>;
+    pub fn replace_dsl_with_token(&mut self, dsl: &str) -> Result<ConsistencyToken, ZanzibarError>;
+    pub fn delete_namespace(&mut self, namespace: &str) -> Result<ConsistencyToken, ZanzibarError>;
+    pub fn delete_relation(
+        &mut self,
+        namespace: &str,
+        relation: &str,
+    ) -> Result<ConsistencyToken, ZanzibarError>;
+}
+
+impl ZanzibarEngine {
+    pub fn replace_schema(&self, source: SchemaSource<'_>) -> Result<ConsistencyToken, EngineError>;
+    pub fn delete_namespace(&self, namespace: &str) -> Result<ConsistencyToken, EngineError>;
+    pub fn delete_relation(&self, namespace: &str, relation: &str) -> Result<ConsistencyToken, EngineError>;
+}
+```
+
+Deletion semantics:
+
+- Deleting a missing namespace returns `NamespaceNotFound`.
+- Deleting a missing relation returns `RelationNotFound`.
+- After any policy change, all existing relationships are revalidated against the candidate schema.
+- If existing relationships reference a deleted namespace/relation, the operation fails and the
+  current engine state is unchanged. Callers can delete relationships first, then delete policy.
+
+This keeps illegal states unrepresentable after a successful schema mutation.
+
+### 4.4 Permission Enumeration APIs
+
+```rust
+pub struct LookupPermissionsRequest {
+    pub subject: User,
+    pub resource: Object,
+    pub consistency: Consistency,
+}
+
+pub struct LookupPermissions {
+    pub permissions: Vec<Relation>,
+}
+
+pub struct LookupObjectPermissionsRequest {
+    pub resource: Object,
+    pub subject_type: String,
+    pub consistency: Consistency,
+}
+
+pub struct LookupObjectPermissions {
+    pub permissions: Vec<PermissionSubjects>,
+}
+
+pub struct PermissionSubjects {
+    pub permission: Relation,
+    pub subjects: Vec<User>,
+}
+```
+
+Service and engine APIs:
+
+```rust
+pub fn lookup_permissions(request: LookupPermissionsRequest) -> Result<LookupPermissions, _>;
+pub fn lookup_object_permissions(
+    request: LookupObjectPermissionsRequest,
+) -> Result<LookupObjectPermissions, _>;
+```
+
+Semantics:
+
+- `lookup_permissions` enumerates the resource namespace's schema relations in sorted order and
+  runs the shared `check` evaluator for each relation.
+- `lookup_object_permissions` enumerates sorted schema relations and runs `lookup_subjects` for the
+  requested subject type. Relations with no subjects are omitted.
+- Subject type remains explicit to keep the API bounded and aligned with Zanzibar lookup semantics.
+- The APIs inherit evaluator depth, fanout, and lookup-result limits.
+
+## 5. Error Model
+
+`ZanzibarError`, `EngineError`, and `SnapshotIoError` remain the primary existing public errors.
+Policy file IO and snapshot-from-policy helpers use:
+
+```rust
+pub enum PolicyIoError {
+    Io { source: std::io::Error },
+    Zanzibar { source: ZanzibarError },
+    Snapshot { source: SnapshotIoError },
+    InvalidExportPath { reason: &'static str },
+}
+```
+
+No helper hides parse, schema, store, consistency, or snapshot validation failures behind strings.
+
+## 6. Performance Budgets
+
+New benchmark filters:
+
+| Benchmark | Dataset | Gate |
+| --- | --- | ---: |
+| `public_api/check/100k` | 100k org rules | <= 10 us |
+| `public_api/lookup_resources/100k` | 100k org rules | <= 10 ms |
+| `public_api/lookup_subjects/100k` | 100k org rules | <= 10 ms |
+| `public_api/lookup_permissions/100k` | 100k org rules | <= 250 us |
+| `public_api/lookup_object_permissions/100k` | 100k org rules | <= 25 ms |
+| `public_api/export_policy_text/100k` | 100k org rules | recorded baseline |
+| `public_api/snapshot_save_zstd/100k` | 100k org rules | recorded baseline |
+| `public_api/snapshot_load_zstd/100k` | 100k org rules | recorded baseline |
+
+The zstd benchmarks are not hard gates for cold-start load speed because the fast path should load a
+cached raw snapshot after decompression. They are still reported in PR comments for distribution-size
+and startup tradeoff visibility.
+
+## 7. Testing Requirements
+
+- zstd snapshot save/load equivalence through `ZanzibarService` and `ZanzibarEngine`.
+- zstd decompression size cap rejects oversized decompressed output.
+- `PolicyText` export/import round trip preserves check, expand, lookup, and permission enumeration.
+- `export_policy_files` creates deterministic `schema.zed` plus grouped sorted relationship files.
+- `replace_dsl`, `delete_namespace`, and `delete_relation` publish new revisions on success and leave
+  state unchanged on invalid deletion.
+- `lookup_permissions` and `lookup_object_permissions` cover direct, computed, tuple-to-userset, and
+  exclusion cases.
+- Existing snapshot corrupt-file validation and trusted fast-load tests continue to pass.
+
+## 8. AGENTS.md Binding
+
+- Error Handling: `thiserror` enums; no `anyhow` in public library APIs.
+- Async & Concurrency: APIs stay synchronous; engine methods acquire existing write/read locks.
+- Type Design & API: policy export structs are owned DTOs with optional serde support; query helpers
+  use request/response types.
+- Safety & Security: bounded decompression; reject path traversal for export file names by deriving
+  filenames from validated resource object types only.
+- Serialization: serde-compatible public DTOs use camelCase and `deny_unknown_fields` where structs
+  are deserialized.
+- Testing: integration tests cover every new public method and error path.
+- Logging & Observability: no relationship payload logging in production code.
+- Performance: no new string parsing in evaluator hot loops; permission enumeration composes existing
+  `check` and lookup APIs.
+- Dependencies: zstd uses `zstd = 0.13.3` after crate-version survey; audit and deny must pass.
+- Documentation: public items get doc comments and examples where concise.
+
+## 9. Cross-References
+
+- Extends public API: [15](./15-public-api-design.md)
+- Uses compact snapshot payload: [17](./17-compact-snapshot-format-design.md)
+- Preserves trusted fast-load boundary: [18](./18-trusted-fast-snapshot-load-design.md)
+- Performance gates: [71](./71-performance-budgets-design.md)
+- Verification gates: [72](./72-testing-verification-plan.md)

--- a/specs/20-concurrent-engine-runtime-design.md
+++ b/specs/20-concurrent-engine-runtime-design.md
@@ -1,0 +1,194 @@
+# 20 - Concurrent Engine Runtime Design
+
+Status: implemented v1
+Owner: Simple Zanzibar
+Depends on: [13-revision-consistency-design.md](./13-revision-consistency-design.md), [15-public-api-design.md](./15-public-api-design.md), [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
+
+## 1. Purpose
+
+This spec removes the legacy mutable public facade and makes `ZanzibarEngine`
+the only crate-facing runtime. Reads must be lock-free over immutable published snapshots. Writes
+must be serialized by a single writer actor, optimized for batch mutation, and horizontally scaled
+by tenant-level sharding rather than fine-grained relationship locks.
+
+The design makes the existing [13-revision-consistency-design.md](./13-revision-consistency-design.md)
+contract true in code: latest reads are one atomic snapshot load plus graph evaluation, and write
+publication is the only place that mutates engine state.
+
+## 2. Architecture
+
+```text
+                         ┌───────────────────────────────────────────────┐
+                         │              ZanzibarEngine                  │
+                         │                                               │
+                         │  ┌─────────────────────────────────────────┐  │
+Read APIs ───────────────┼─▶│ ArcSwapOption<EngineState>              │  │
+check / expand / lookup  │  │ - latest PublishedSnapshot              │  │
+export / save snapshot   │  │ - retained exact-snapshot history       │  │
+                         │  │ - datastore id + latest revision        │  │
+                         │  │ - evaluation limits                     │  │
+                         │  └─────────────────────────────────────────┘  │
+                         │                         ▲                     │
+Write APIs ──────────────┼──────────────┐          │ atomic publish      │
+schema / relationships   │              │          │                     │
+policy import            │              ▼          │                     │
+                         │  ┌─────────────────────────────────────────┐  │
+                         │  │ Single Writer Actor                    │  │
+                         │  │ - bounded command queue                │  │
+                         │  │ - owns mutable WriterState             │  │
+                         │  │ - batches caller-supplied mutations    │  │
+                         │  │ - validates preconditions atomically   │  │
+                         │  └─────────────────────────────────────────┘  │
+                         └───────────────────────────────────────────────┘
+
+              ┌────────────────────────────────────────────────────────┐
+              │ ZanzibarTenantShards                                  │
+              │                                                        │
+              │ ArcSwap<HashMap<TenantId, Arc<ZanzibarEngine>>>        │
+              │ - existing tenant lookup is lock-free                  │
+              │ - tenant creation clones the map under a short gate    │
+              │ - each tenant has independent writer actor/revisions   │
+              └────────────────────────────────────────────────────────┘
+```
+
+## 3. Public Interface
+
+The legacy mutable facade is removed from the public API. The public runtime surface is:
+
+```rust
+pub struct ZanzibarEngine { /* private */ }
+pub struct ZanzibarEngineBuilder { /* private */ }
+
+impl ZanzibarEngine {
+    pub fn builder() -> ZanzibarEngineBuilder;
+    pub fn check(&self, request: CheckRequest) -> Result<CheckResponse, EngineError>;
+    pub fn check_relation(&self, object: &Object, relation: &Relation, user: &User) -> Result<bool, EngineError>;
+    pub fn expand(&self, request: ExpandRequest) -> Result<ExpandResponse, EngineError>;
+    pub fn expand_relation(&self, object: &Object, relation: &Relation) -> Result<ExpandedUserset, EngineError>;
+    pub fn lookup_resources(&self, request: impl Borrow<LookupResourcesRequest>) -> Result<LookupResources, EngineError>;
+    pub fn lookup_subjects(&self, request: impl Borrow<LookupSubjectsRequest>) -> Result<LookupSubjects, EngineError>;
+    pub fn lookup_permissions(&self, request: impl Borrow<LookupPermissionsRequest>) -> Result<LookupPermissions, EngineError>;
+    pub fn lookup_object_permissions(&self, request: impl Borrow<LookupObjectPermissionsRequest>) -> Result<LookupObjectPermissions, EngineError>;
+    pub fn add_dsl(&self, dsl: &str) -> Result<(), EngineError>;
+    pub fn apply_schema(&self, source: SchemaSource<'_>) -> Result<ConsistencyToken, EngineError>;
+    pub fn write_relationships(&self, mutations: impl IntoIterator<Item = RelationshipMutation>) -> Result<ConsistencyToken, EngineError>;
+    pub fn write_relationships_with_preconditions(
+        &self,
+        mutations: impl IntoIterator<Item = RelationshipMutation>,
+        preconditions: impl IntoIterator<Item = Precondition>,
+    ) -> Result<ConsistencyToken, EngineError>;
+    pub fn save_snapshot(&self, path: impl AsRef<Path>, options: SnapshotSaveOptions) -> Result<(), SnapshotIoError>;
+    pub fn load_snapshot(path: impl AsRef<Path>, options: SnapshotLoadOptions) -> Result<Self, SnapshotIoError>;
+}
+
+pub struct ZanzibarTenantShards { /* private */ }
+pub struct TenantId { /* private */ }
+
+impl ZanzibarTenantShards {
+    pub fn new(builder: ZanzibarEngineBuilder) -> Self;
+    pub fn get(&self, tenant: &TenantId) -> Option<Arc<ZanzibarEngine>>;
+    pub fn get_or_create(&self, tenant: TenantId) -> Arc<ZanzibarEngine>;
+    pub fn tenants(&self) -> Vec<TenantId>;
+}
+```
+
+`write_relationships` remains the primary write API and accepts batches. Single-relationship
+helpers remain convenience wrappers and are not optimized as a separate write path.
+
+## 4. Invariants
+
+- I1: Public reads never acquire a `Mutex` or `RwLock`; they clone `Arc<EngineState>` from
+  `ArcSwapOption`.
+- I2: Every successful write publishes exactly one new `PublishedSnapshot`, increments the local
+  revision by one, and returns a token for that revision.
+- I3: Failed writes publish no state and leave the previously loaded `EngineState` observable.
+- I4: Exact consistency tokens are scoped to one tenant engine because each tenant has its own
+  datastore id.
+- I5: The writer actor is the only owner of mutable schema, relationship, and snapshot-history
+  state for one engine.
+- I6: Tenant sharding is a runtime partitioning boundary. Relationships are not tagged with tenant
+  id inside one engine.
+
+## 5. Behaviour
+
+### Reads
+
+Latest reads fail with `SchemaRequired` if no snapshot has been published. Exact reads validate
+datastore id, revision range, retained-history presence, and schema hash using the immutable
+`EngineState` loaded at the beginning of the request.
+
+Policy export and snapshot save clone the latest `PublishedSnapshot` first and perform sorting,
+serialization, compression, and file I/O after the atomic load. They do not hold a writer gate.
+
+### Writes
+
+Every write command travels through a bounded sync channel to the writer actor. The public call
+waits on a one-shot response channel and returns the typed result. If the actor has shut down or
+panicked, the call returns `EngineError::WriterUnavailable`.
+
+The writer actor processes one command at a time:
+
+```text
+Client               Writer Actor                 ArcSwap EngineState
+  │                        │                                  │
+  │ 1. command + response  │                                  │
+  │───────────────────────▶│                                  │
+  │                        │ 2. validate against owned state  │
+  │                        │ 3. build candidate store/schema  │
+  │                        │ 4. assign revision/token         │
+  │                        │ 5. publish Arc<EngineState> ────▶│
+  │                        │                                  │
+  │ 6. typed result ◀──────│                                  │
+```
+
+Batch writes are the throughput path. Callers with high write rates should accumulate related
+relationship mutations into one `write_relationships` call so the engine pays one queue handoff,
+one validation pass, and one snapshot publication.
+
+### Tenant Shards
+
+`ZanzibarTenantShards` is a convenience owner for many independent engines. Existing tenant lookups
+load an immutable map through `ArcSwap`, so routing a request to a tenant has no lock in the hot
+path. Creating a missing tenant takes a short creation gate, clones the small tenant map, inserts a
+new `Arc<ZanzibarEngine>`, and atomically publishes the new map.
+
+This is the only write-scaling strategy in this milestone. Fine-grained locks inside one tenant are
+deferred because preconditions, schema changes, global revision tokens, and snapshot publication all
+require a single linearized write order.
+
+## 6. Performance Verification
+
+The benchmark suite adds `concurrent_runtime` with these scenarios:
+
+| Scenario | Shape | Required output |
+| --- | --- | --- |
+| read-heavy/light-write | many reader threads, one small batched writer | read throughput, write p50/p95 |
+| read-heavy/medium-write unbatched | many reader threads, writers submit one mutation at a time | read throughput, write p50/p95 |
+| read-heavy/medium-write batched | same logical write volume batched by 100 | read throughput, write p50/p95 |
+| read-heavy/heavy-write unbatched | many readers and sustained single-mutation writers | read throughput, write p50/p95 |
+| read-heavy/heavy-write batched | same logical write volume batched by 100 or 1k | read throughput, write p50/p95 |
+| tenant-sharded heavy-write | same total logical write volume split across tenants | per-tenant and aggregate write throughput |
+
+The benchmark must report results in the PR comment. The first implementation records baselines
+rather than setting hard gates; future gates are allowed only after the new runtime has evidence.
+
+## 7. AGENTS Binding
+
+- Error Handling: actor send/receive failures map to typed `EngineError`; no `anyhow` in library.
+- Async & Concurrency: the runtime uses message passing and an actor that owns mutable state. The
+  public API stays synchronous per [99-key-decisions.md D5](./99-key-decisions.md#d5---keep-the-core-synchronous).
+- Type Design & API: `TenantId` is a validated newtype; writer queue capacity is `NonZeroUsize`.
+- Safety & Security: no unsafe; no unchecked indexing; file, policy, schema, and relationship
+  inputs keep existing validation boundaries.
+- Serialization: unchanged request/response serde feature behaviour.
+- Testing: actor lifecycle, failed-write atomicity, concurrent read/write, and tenant isolation
+  tests are required.
+- Logging & Observability: existing `tracing` API spans remain at the public method boundary.
+- Performance: reads must not take locks; benchmark evidence must cover write batching and sharding.
+- Documentation: public docs and examples use `ZanzibarEngine`, not the legacy mutable facade.
+
+## 8. Cross-References
+
+- <- Depends on: [13-revision-consistency-design.md](./13-revision-consistency-design.md), [15-public-api-design.md](./15-public-api-design.md), [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
+- -> Consumed by: [71-performance-budgets-design.md](./71-performance-budgets-design.md), [72-testing-verification-plan.md](./72-testing-verification-plan.md), [90-local-engine-roadmap.md](./90-local-engine-roadmap.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
+- Related research: [../docs/research/study-spicedb.md § Relationship Writes](../docs/research/study-spicedb.md#relationship-writes), [../docs/research/study-spicedb.md § Revision Tokens](../docs/research/study-spicedb.md#revision-tokens)

--- a/specs/21-performance-optimization-design.md
+++ b/specs/21-performance-optimization-design.md
@@ -1,0 +1,584 @@
+# 21 - Performance Optimization Design
+
+Status: draft v1
+Owner: Simple Zanzibar
+Last updated: 2026-05-24
+Depends on: [16](./16-compact-relationship-store-design.md), [17](./17-compact-snapshot-format-design.md), [18](./18-trusted-fast-snapshot-load-design.md), [20](./20-concurrent-engine-runtime-design.md), [71](./71-performance-budgets-design.md)
+
+## 1. Purpose
+
+M10 made `ZanzibarEngine` the only public runtime, moved reads to immutable snapshots, and added
+single-writer actor plus tenant sharding. The current engine is now correct and practical at
+1M-rule scale, but the performance profile still has structural ceilings:
+
+- writes copy too much unchanged state;
+- some evaluator and lookup paths still bounce through legacy string/domain objects;
+- full snapshot load repeats semantic proof that trusted build-pipeline artifacts can avoid;
+- snapshot save/load still materializes full payloads in memory;
+- every loaded store currently carries the full index set even when the application only needs
+  checks.
+
+This spec is the dependency-ordered plan for the next optimization pass. It keeps correctness and
+the safe default trust boundary ahead of raw speed: the hard <= 200 ms 1M-rule load target remains
+the explicit trusted fast-load path, while the default full loader continues to validate hostile
+files.
+
+## 2. Current Evidence
+
+Measured 2026-05-23 on the reference macOS machine:
+
+| Area | Current evidence | Notes |
+| --- | ---: | --- |
+| raw 1M full snapshot load | `[555.68 ms, 559.30 ms, 563.48 ms]` | safe default full validation |
+| raw 1M trusted fast load | `[135.78 ms, 137.06 ms, 138.67 ms]` | `TrustedFastLoad + External` |
+| zstd 1M direct load | `[625.35 ms, 628.92 ms, 632.45 ms]` | compressed transport, not fastest startup path |
+| raw 1M `.szsnap` size | `124,422,241 bytes` | uncompressed v2 artifact |
+| zstd 1M `.szsnap` size | `33,162,371 bytes` | 26.7% of raw bytes |
+| 1M full-load max RSS | `436,076,544 bytes` | load-time peak, not steady state |
+| realworld mixed read | `[63.188 us, 63.394 us, 63.577 us]` | 1M realistic SaaS sample |
+| single-tenant heavy batched writes | `111,872 logical writes/s; p95 9,921 us` | 100k base concurrent benchmark |
+| tenant-sharded heavy batched writes | `419,072 logical writes/s; p95 2,753 us` | sharding proves partitioning helps |
+
+Concrete code bottlenecks observed in the current implementation:
+
+| Finding | Code evidence | Structural issue |
+| --- | --- | --- |
+| full-store clone on write | `src/lib.rs:344`, `src/relationship.rs:448`, `src/relationship.rs:528` | each write batch can copy rows, symbols, uniqueness, and seven indexes |
+| writer submit mutex spans blocking send | `src/api.rs:1113`, `src/api.rs:1169` | a full bounded queue can serialize submitter threads before the actor sees work |
+| evaluator still creates owned keys and legacy relations | `src/eval.rs:194`, `src/eval.rs:280`, `src/eval.rs:344`, `src/eval.rs:721` | recursive checks allocate/convert on hot paths |
+| lookup allocates and re-checks candidates | `src/eval.rs:615`, `src/eval.rs:672`, `src/eval.rs:689` | fresh contexts and owned objects per candidate |
+| full load decodes indexes sequentially with per-index coverage buffers | `src/relationship.rs:2577`, `src/relationship.rs:2820` | safe but leaves parallel CPU and RSS reductions unused |
+| full load keeps eager uniqueness | `src/relationship.rs:3247`, `src/relationship.rs:3292` | uniqueness is needed for writes, not read-only startup |
+| snapshot save/load copies full payloads | `src/snapshot.rs:484`, `src/snapshot.rs:495`, `src/snapshot.rs:518`, `src/snapshot.rs:582` | whole-section and whole-file buffers increase transient memory |
+| every store carries all seven indexes | `src/relationship.rs:419`, `src/relationship.rs:423` | check-only deployments pay lookup-index memory and disk cost |
+
+## 3. Goals
+
+| # | Goal | Measure |
+| --- | --- | --- |
+| G1 | Reduce single-tenant write amplification. | 1M-base write benchmarks must show at least 3x lower p95 for small/mixed writes after the segmented store lands, or this spec must be recalibrated with profile evidence. |
+| G2 | Improve read latency without weakening semantics. | Realworld 1M inherited checks and mixed-read workload should improve by >= 10% with no public API behavior change; no existing hot-path benchmark may regress by > 5%. |
+| G3 | Keep the <= 200 ms load path explicit and safe. | `snapshot_load_trusted_fast/1m` remains <= 200 ms; default `Full` validation never silently skips semantic checks. |
+| G4 | Lower default full-load cost where safe. | `snapshot_load_compact/1m` full mode target after loader optimization: upper estimate <= 450 ms, with load-time max RSS <= 400 MiB. |
+| G5 | Reduce memory and disk for narrow use cases. | A check-only index profile must reduce 1M raw snapshot bytes and steady-state store memory by >= 20% versus `Full`, while preserving direct/inherited check budgets. |
+| G6 | Make performance evidence reproducible. | Every phase adds or updates Makefile-discoverable benchmark targets and records Criterion estimates plus RSS where relevant. |
+
+## 4. Non-Goals
+
+- No `unsafe` and no mmap in this pass. Memory mapping can be reconsidered only with a safe wrapper,
+  a separate threat model update, and evidence that read/copy cost is still dominant after this spec.
+- No weakening of the default snapshot loader. Hostile files still use `SnapshotValidationMode::Full`.
+- No distributed datastore, network watch protocol, or cross-process consistency.
+- No fine-grained relationship locks inside one tenant. The write order remains linearized per
+  engine; throughput comes from smaller write deltas, caller batching, and tenant sharding.
+- No public global "dump every subject and every permission" query.
+- No new dependency is required by this design. If implementation later needs a channel or
+  parallelism crate, [60-crates-features-design.md](./60-crates-features-design.md) and
+  [99-key-decisions.md](./99-key-decisions.md) must be updated after a current dependency review.
+
+## 5. Optimization Map
+
+```text
++--------------------------------------------------------------------------------+
+| ZanzibarEngine public API                                                      |
+|                                                                                |
+|  Read calls                                                                    |
+|    |                                                                           |
+|    v                                                                           |
+|  +-----------------------+      +-----------------------+                       |
+|  | ArcSwap EngineState   |----->| ID-native evaluator   |                       |
+|  | immutable snapshots   |      | reusable contexts     |                       |
+|  +-----------+-----------+      +-----------+-----------+                       |
+|              |                              |                                   |
+|              v                              v                                   |
+|  +-----------------------+      +-----------------------+                       |
+|  | Store view            |<-----| Streaming lookup      |                       |
+|  | checkpoint + deltas   |      | bounded candidates    |                       |
+|  +-----------+-----------+      +-----------------------+                       |
+|              ^                                                                  |
+|              | publish immutable revision                                       |
+|  +-----------+-----------+                                                      |
+|  | Single writer actor  |                                                      |
+|  | batch + delta write  |                                                      |
+|  +-----------+-----------+                                                      |
+|              |                                                                  |
+|              v                                                                  |
+|  +-----------------------+      +-----------------------+                       |
+|  | Snapshot save/load    |<---->| Index profile policy |                       |
+|  | full/trusted/zstd     |      | full/check-only/etc. |                       |
+|  +-----------------------+      +-----------------------+                       |
+|                                                                                |
++--------------------------------------------------------------------------------+
+```
+
+The design follows an rsync-like principle: avoid redoing work whose result can be proven once and
+reused. For snapshots, trusted fast-load reuses build-time semantic proof. For writes, segmented
+store deltas publish only the changed rows instead of cloning unchanged indexes. For lookup, reusable
+contexts and streaming traversal avoid rebuilding the same temporary state per candidate. This is
+not a network delta-sync protocol; it is the same optimization idea applied inside one process.
+
+## 6. Priority 1 - Low-Risk Fixes
+
+These changes are intentionally small and should land before larger architecture work.
+
+### 6.1 Writer Submit Without Blocking Mutex
+
+`WriterActor` should keep a cloneable bounded sender directly:
+
+```rust
+struct WriterActor {
+    sender: SyncSender<WriterCommand>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+    shutdown: AtomicBool,
+}
+```
+
+`send` clones or borrows the sender without holding a mutex across `SyncSender::send`. Drop uses
+`shutdown.swap(true, Ordering::AcqRel)` and sends `WriterCommand::Shutdown` at most once, then joins
+the handle.
+
+Invariants:
+
+- a full queue still applies backpressure to callers;
+- submitter threads are not serialized by a sender mutex while blocked;
+- actor shutdown still returns `EngineError::WriterUnavailable`;
+- no write command is accepted after shutdown starts.
+
+### 6.2 Duplicate Schema Lookup Removal
+
+Public `check` validates the object relation, and `EvaluationContext::check_entered` validates it
+again. The read path should validate once and pass a prepared relation handle into the evaluator:
+
+```rust
+struct PreparedCheck<'a> {
+    object: &'a Object,
+    relation: &'a Relation,
+    subject: &'a User,
+    relation_definition: &'a SchemaRelationDefinition,
+}
+```
+
+The public API keeps the same signature. Internally, `check_with_snapshot` gains a prepared variant
+used by `ZanzibarEngine::check`, `lookup_permissions`, and lookup verification loops.
+
+### 6.3 Lazy Write Uniqueness After Full Load
+
+Full snapshot load should use a temporary duplicate detector for row validation and then drop it
+before publishing read-only state. The store records:
+
+```rust
+enum UniquenessState {
+    Ready(RelationshipIdentityIndex),
+    KnownUniqueButNotIndexed,
+    UntrustedNotIndexed,
+}
+```
+
+`Full` load publishes `KnownUniqueButNotIndexed`; `TrustedFastLoad` publishes
+`UntrustedNotIndexed`. The first mutation builds the index once. If `UntrustedNotIndexed` discovers
+duplicates during lazy build, the mutation fails with a typed store invariant error and publishes no
+new revision.
+
+### 6.4 Sorted Relation Cache
+
+Permission enumeration currently sorts schema relations per call. `CompiledSchema` should store
+relation definitions in both canonical map form and stable sorted order per namespace. The cache is
+rebuilt only when schema changes, so `lookup_permissions` and `lookup_object_permissions` can
+iterate without allocation or sort.
+
+### 6.5 All-Live Row Fast Path
+
+`LiveRows::full(row_count)` means no tombstones exist. Iterators should carry a fast-path state that
+skips `live_rows.contains(row_id)` until the first delete/compaction introduces tombstones. The
+fast path must preserve the checked `rows.get(row_id.index())` access.
+
+## 7. Priority 2 - ID-Native Evaluation
+
+The evaluator should stop converting typed schema relations back into legacy `Relation(String)` and
+then reparsing them. The internal check key becomes compact and ID-native:
+
+```rust
+struct EvalObject {
+    object_type: ObjectTypeId,
+    object_id: ObjectIdId,
+}
+
+struct EvalSubject {
+    subject_type: SubjectTypeId,
+    subject_id: SubjectIdId,
+    subject_relation: Option<RelationId>,
+}
+
+struct EvalCheckKey {
+    object: EvalObject,
+    relation: RelationId,
+    subject: EvalSubject,
+}
+```
+
+Public `Object`, `Relation`, and `User` remain the public API. The snapshot prepares internal IDs
+once per request, and recursive computed-userset / tuple-to-userset evaluation passes IDs directly.
+Materializing legacy `Object` and `Relation` values is allowed only at public response boundaries.
+
+Required behavior:
+
+- recursion detection uses `EvalCheckKey`, not cloned public model structs;
+- computed userset and tuple-to-userset relations store `RelationId` in compiled schema metadata;
+- `RelationshipRef::subject_userset_legacy` is removed from hot check recursion and replaced with
+  an ID-native subject userset accessor;
+- every public error remains the same typed error category as before.
+
+## 8. Priority 3 - Streaming Lookup
+
+Lookup APIs must keep the existing bounded Vec-returning public surface, but internals should avoid
+collecting candidates and allocating fresh evaluation contexts for every candidate.
+
+### 8.1 Reusable Evaluation Contexts
+
+`EvaluationContext` should support per-candidate reset with generation counters:
+
+```rust
+struct VisitGeneration(NonZeroU32);
+
+struct ReusableEvaluationContext<'a> {
+    snapshot: &'a PublishedSnapshot,
+    limits: EvaluationLimits,
+    generation: VisitGeneration,
+    visited_checks: HashMap<EvalCheckKey, VisitGeneration>,
+    expanded: HashMap<EvalExpandKey, VisitGeneration>,
+}
+```
+
+Reset increments the generation; when it overflows, the maps are cleared and generation restarts at
+one. This preserves cycle detection while reducing allocation churn in lookup loops.
+
+### 8.2 Candidate Streaming
+
+`lookup_subjects` should stream candidates from expansion into verification and output limits. It
+must not build an unbounded intermediate `Vec<User>`.
+
+`lookup_resources` should reuse one context for the BFS and verification loop. It should also keep
+direct-resource candidates as borrowed/ID-native objects until the final response vector.
+
+### 8.3 Safe Shortcuts
+
+The evaluator may skip the final `check` only when the candidate proof is exact under the compiled
+schema expression:
+
+- direct `this` relation candidate on the requested object/relation;
+- computed userset where the recursive check proof already returned allowed for the same subject;
+- tuple-to-userset proof whose intermediate edge and computed relation were both evaluated in the
+  same context.
+
+Exclusion, intersection, fanout-limit, and depth-limit cases must continue to verify through the
+normal check algebra.
+
+## 9. Priority 4 - Snapshot Load and Save
+
+### 9.1 Phase Timers
+
+Snapshot benchmarks must expose these phase timings behind benchmark-only instrumentation:
+
+```text
+file_read
+decompression
+header_and_sections
+checksum
+schema_parse_compile
+symbols
+rows
+indexes
+publish
+```
+
+The timers are not a public runtime API. They exist so future PR comments cannot conflate
+relationship generation, Criterion harness overhead, compressed transport, and pure load time.
+
+### 9.2 Parallel Index Decode
+
+Full validation may decode independent index groups in parallel using `std::thread::scope` and a
+bounded worker count from `std::thread::available_parallelism`. The implementation must cap workers
+to the number of index groups and preserve deterministic error reporting by returning the first
+index in fixed section order that fails.
+
+Parallel decoding may allocate one coverage buffer per active index group. For 1M rows this is
+small relative to current load RSS, but the worker cap must be configurable internally so memory
+benchmarks can compare sequential and parallel modes.
+
+### 9.3 Fixed Section Lookup
+
+`SnapshotReader` should replace generic section lookup maps with a fixed section table keyed by
+`SectionKind`. The current section set is small and versioned; an array avoids hash work during
+every load and makes duplicate/missing-section checks direct.
+
+### 9.4 Streaming Snapshot Writer
+
+The writer should stop building all section payloads plus a final encoded Vec before `fs::write`.
+The target shape:
+
+1. precompute section lengths and offsets;
+2. write header and section directory to a temp file through `BufWriter`;
+3. stream schema, symbols, rows, index keys, posting ranges, posting row ids, and optional lookup
+   sections;
+4. update BLAKE3 while bytes are written;
+5. write footer and atomically rename the temp file into place.
+
+For `SnapshotCompression::Zstd`, the raw payload may be streamed through a zstd encoder, but the
+inner `.szsnap` footer checksum still covers the raw payload. The fastest startup recommendation
+remains: distribute zstd, decompress once into a content-addressed raw cache, then load the raw
+artifact with `TrustedFastLoad + External`.
+
+## 10. Priority 5 - Segmented Store and Delta Publication
+
+The current copy-on-write strategy clones the entire `IndexedRelationshipStore` before a write. The
+next store architecture should publish immutable views made of a checkpoint plus bounded deltas.
+
+```text
+                 exact revision N
+        +--------------------------------+
+        | StoreView                      |
+        | checkpoint: Arc<StoreSegment>  |
+        | deltas: Arc<[StoreDelta]>      |
+        +---------------+----------------+
+                        |
+      query             | merge candidates, mask tombstones
+        v               v
++---------------+  +----------------+  +----------------+
+| checkpoint    |  | delta N-2      |  | delta N-1      |
+| full indexes  |  | inserts/deletes|  | inserts/deletes|
++---------------+  +----------------+  +----------------+
+
+writer command
+        |
+        v
+validate against StoreView -> build one new immutable delta -> publish new StoreView
+```
+
+### 10.1 StoreDelta
+
+`StoreDelta` owns only changes from one successful write publication:
+
+```rust
+struct StoreDelta {
+    inserted: IndexedRelationshipStore,
+    deleted: RelationshipIdentitySet,
+    mutation_count: NonZeroUsize,
+}
+```
+
+The inserted store may use its own small interner. Querying a `StoreView` asks each segment for
+matching candidates and filters any candidate whose relationship identity is deleted by a newer
+delta. Segment count stays bounded by checkpoint thresholds.
+
+### 10.2 Checkpointing
+
+The writer actor creates a new checkpoint when any threshold trips:
+
+- `deltas.len() > max_delta_segments`;
+- total delta mutations exceed `max_delta_mutations`;
+- tombstone checks exceed a measured ratio of returned candidates;
+- snapshot save requests a compact full artifact and no recent checkpoint exists.
+
+Checkpointing merges checkpoint + deltas into one `IndexedRelationshipStore`, compacts tombstones,
+and publishes a new `StoreView` with no deltas. Exact revisions retain their older `Arc<StoreView>`
+until revision-history retention expires.
+
+### 10.3 Correctness Invariants
+
+- Query results from `StoreView` are equivalent to applying every retained delta in revision order
+  to the checkpoint.
+- Newer deletes mask older inserted/base rows; newer touches must not produce duplicates.
+- Preconditions evaluate against the writer's current `StoreView` before the new delta is created.
+- A failed write creates no delta and publishes no revision.
+- Exact tokens continue to observe the exact `StoreView` that was current at publication time.
+- Snapshot save always writes a canonical compact artifact equivalent to the view, not the physical
+  delta layout.
+
+### 10.4 Tradeoff
+
+Segmented deltas shift cost from writes to reads. Reads may inspect a small number of delta
+segments and tombstone sets before checkpointing. This is acceptable only while delta thresholds
+keep the read overhead bounded and benchmarks prove no > 5% regression in read-heavy workloads.
+
+## 11. Priority 6 - Index Profiles
+
+The full seven-index store is correct for the complete API, but not every deployment needs every
+query family. Add explicit index profiles:
+
+```rust
+pub enum IndexProfile {
+    Full,
+    CheckOnly,
+    CheckAndObjectAudit,
+}
+```
+
+Rules:
+
+- `Full` is the default and supports every public API plus writes.
+- `CheckOnly` keeps resource-side indexes needed for `check`, `expand`, tuple-to-userset, and
+  object-bounded permission checks. It does not support `lookup_resources`.
+- `CheckAndObjectAudit` keeps resource-side indexes and the minimum subject-type traversal needed
+  for `lookup_subjects` / `lookup_object_permissions`; it may still reject `lookup_resources` if no
+  subject reverse index exists.
+- Unsupported operations return a typed `EngineError::UnsupportedIndexProfile` instead of scanning.
+- Snapshot artifacts record the index profile in the header or a required options section.
+- `SnapshotLoadOptions` may reject loading an artifact whose profile cannot satisfy requested
+  builder capabilities.
+
+The default public experience remains hard to misuse: users who do not choose a profile get `Full`.
+Profiles are an explicit memory/disk optimization for applications with a narrow query surface.
+
+## 12. Performance Budgets
+
+| Phase | Benchmark | Gate |
+| --- | --- | --- |
+| P1 quick fixes | existing `public_api/check/100k`, `snapshot_load_compact/1m`, concurrent runtime suite | no > 5% regression; writer submit contention recorded |
+| P2 ID-native eval | `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | >= 10% improvement or profile-backed recalibration |
+| P2 ID-native eval | `realworld_authorization/1m_rules/mixed_read_workload` | upper estimate <= 55 us |
+| P3 lookup | `public_api/lookup_resources/100k` | no regression; allocation count lower than baseline |
+| P4 full loader | `snapshot_load_compact/1m` | upper estimate <= 450 ms |
+| P4 full loader | `snapshot_load_peak_rss/1m` | max RSS <= 400 MiB |
+| P4 trusted loader | `snapshot_load_trusted_fast/1m` | upper estimate <= 200 ms |
+| P5 segmented writes | `perf_optimization/write_single_touch_1m` | p95 improves >= 3x versus pre-change 1M baseline |
+| P5 segmented writes | `perf_optimization/read_heavy_heavy_write_batched_1m` | read throughput no > 5% regression; write p95 improves >= 2x |
+| P6 index profiles | `snapshot_file_size_check_only/1m` and RSS equivalent | >= 20% reduction versus `Full` |
+
+Every target is measured in release builds. If a target fails, the implementation must include a
+profile or phase timing that explains whether the design assumption was wrong or the implementation
+is incomplete.
+
+## 13. Verification
+
+Required new tests:
+
+- writer actor shutdown and queue-full behavior without sender mutex serialization;
+- full-load lazy uniqueness followed by create/touch/delete;
+- trusted-load lazy uniqueness failure on a crafted duplicate-row fixture;
+- prepared-check equivalence against the public `check` path;
+- ID-native recursion, computed userset, tuple-to-userset, intersection, exclusion, and cycle tests;
+- streaming lookup result equivalence and limit enforcement;
+- segmented store property tests comparing random mutation sequences to a reference `HashSet`;
+- checkpoint property tests preserving exact revision behavior;
+- index-profile operation support and typed unsupported-operation errors;
+- snapshot save/load round trips for every index profile.
+
+Required benchmark additions:
+
+```text
+perf_optimization/writer_submit_queue_full
+perf_optimization/check_prepared_1m
+perf_optimization/lookup_subjects_streaming_1m
+perf_optimization/lookup_resources_streaming_1m
+perf_optimization/write_single_touch_1m
+perf_optimization/write_mixed_batch_1m
+perf_optimization/read_heavy_light_write_1m
+perf_optimization/read_heavy_medium_write_unbatched_1m
+perf_optimization/read_heavy_medium_write_batched_1m
+perf_optimization/read_heavy_heavy_write_unbatched_1m
+perf_optimization/read_heavy_heavy_write_batched_1m
+snapshot_load_compact/1m with phase timers
+snapshot_load_peak_rss/1m
+snapshot_file_size_check_only/1m
+```
+
+Add a Makefile target named `bench-perf-optimization` when the benchmark binary lands. Do not add ad
+hoc shell scripts.
+
+## 14. Phasing
+
+### Phase 12.0 - Measurement Spine
+
+- add phase timers for snapshot load;
+- add 1M write and mixed read/write benchmarks;
+- record pre-change baseline in [71](./71-performance-budgets-design.md).
+
+Exit gate: baseline evidence exists for every P1-P6 target.
+
+### Phase 12.1 - Low-Risk Fixes
+
+- remove writer sender mutex from the submit path;
+- remove duplicate schema lookup in prepared checks;
+- add sorted relation cache;
+- add all-live row iterator fast path;
+- switch full-load uniqueness to lazy retained state.
+
+Exit gate: existing correctness tests pass; no benchmark regresses by > 5%.
+
+### Phase 12.2 - ID-Native Evaluation and Streaming Lookup
+
+- add `EvalObject`, `EvalSubject`, and `EvalCheckKey`;
+- compile relation IDs into schema expression nodes;
+- remove legacy relation/object materialization from recursive check;
+- add reusable lookup evaluation contexts and candidate streaming.
+
+Exit gate: evaluator equivalence tests pass and realworld read targets in section 12 are met or
+recalibrated with profile evidence.
+
+### Phase 12.3 - Snapshot Loader/Writer Optimization
+
+- fixed section lookup table;
+- optional bounded parallel index decode;
+- streaming snapshot writer;
+- zstd streaming decode/write only if it reduces measured RSS without hurting safety.
+
+Exit gate: full-load, trusted-load, zstd-load, and RSS benchmarks are recorded.
+
+### Phase 12.4 - Segmented Store
+
+- introduce `StoreView`, `StoreDelta`, and checkpoint thresholds internally;
+- preserve exact revisions with immutable `Arc<StoreView>`;
+- make writer publication append one delta instead of cloning the full store;
+- keep snapshot save canonical and independent of physical delta layout.
+
+Exit gate: random mutation property tests pass and 1M write benchmarks meet section 12.
+
+### Phase 12.5 - Index Profiles
+
+- add profile metadata to runtime state and `.szsnap`;
+- save/load `Full`, `CheckOnly`, and `CheckAndObjectAudit`;
+- return typed unsupported-operation errors for unsupported lookup APIs;
+- document builder and snapshot-option ergonomics.
+
+Exit gate: profile-specific tests pass and memory/disk reduction is measured.
+
+## 15. AGENTS.md Binding
+
+- Error Handling: all new failure modes use typed library errors with `thiserror`; no string-only
+  error erasure.
+- Async & Concurrency: the public core remains synchronous per [99-key-decisions.md D5](./99-key-decisions.md#d5---keep-the-core-synchronous);
+  concurrency is actor/message-passing plus immutable snapshots, not shared mutable locks.
+- Type Design & API: profile and validation modes are enums, not booleans; builder fields with more
+  than five settings use `typed-builder` if they become public structs.
+- Safety & Security: no `unsafe`, no `unwrap`/`expect`, no unchecked indexing in boundary or
+  snapshot code; every external byte count and range stays checked.
+- Serialization: `.szsnap` version/profile changes remain explicit and reject unsupported versions.
+- Testing: unit, integration, property, corrupt-file, exact-revision, and benchmark gates in section 13
+  are required before implementation is complete.
+- Logging & Observability: benchmark-only timers must not leak into stable public API; public spans
+  may include phase names but not relationship data.
+- Performance: no optimization claim without Criterion/RSS evidence; no speculative dependency
+  additions without a dependency review.
+- Documentation: public docs must explain when `TrustedFastLoad`, zstd, and index profiles are
+  appropriate.
+
+## 16. Risks and Open Questions
+
+- Segmented deltas may hurt read-heavy latency if checkpoint thresholds are too high. Thresholds
+  must be benchmark-driven and conservative by default.
+- ID-native evaluation and segmented local interners interact. The first segmented implementation
+  may translate filters per segment while segment counts are low; a chunked global symbol arena is a
+  future option if profiles prove translation cost dominates.
+- Parallel index decode may reduce CPU time but increase transient allocations. RSS gates decide
+  whether it stays enabled by default.
+- Check-only profiles complicate API support. The default remains `Full`; narrow profiles must fail
+  unsupported operations loudly.
+- A default full loader with hostile-file semantic validation is unlikely to reach <= 200 ms without
+  moving proof out of startup, adding mmap/zero-copy, or changing the safety boundary. This spec
+  deliberately keeps <= 200 ms as the trusted artifact path.
+
+## 17. Cross-References
+
+- <- Depends on: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md), [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md), [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md), [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md)
+- -> Consumed by: [72-testing-verification-plan.md](./72-testing-verification-plan.md), [90-local-engine-roadmap.md](./90-local-engine-roadmap.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
+- Related research: [../docs/research/study-spicedb.md](../docs/research/study-spicedb.md)

--- a/specs/60-crates-features-design.md
+++ b/specs/60-crates-features-design.md
@@ -44,7 +44,7 @@ The existing `model.rs`, `store.rs`, `eval.rs`, and `parser.rs` are retired once
 | `std` | yes | Standard library support. Required for v2. |
 | `serde` | no | Serialize request/response/domain types. |
 | `tracing` | no | Emit structured spans. |
-| `compat` | yes during v2 migration | Keep legacy `ZanzibarService` facade. |
+| `compat` | removed before API stabilization | Legacy legacy mutable facade was retired by [20](./20-concurrent-engine-runtime-design.md). |
 | `bench-internals` | no | Expose benchmark-only constructors and counters. |
 
 No network or runtime feature is part of v2.

--- a/specs/60-crates-features-design.md
+++ b/specs/60-crates-features-design.md
@@ -68,6 +68,7 @@ Dependency versions checked with `cargo search` on 2026-05-23:
 | `criterion` | `0.8.2` | performance benchmarks | Adopt as dev-dependency when benchmark phase starts. |
 | `proptest` | `1.11.0` | property tests | Adopt as dev-dependency for store/schema invariants. |
 | `rstest` | `0.26.1` | parameterized tests | Adopt as dev-dependency for validation matrices. |
+| `zstd` | `0.13.3` | snapshot compression wrapper | Adopt for [19](./19-public-api-completeness-design.md) with default features disabled. |
 
 Any dependency added during implementation must pass `cargo audit` and `cargo deny check`.
 

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -208,6 +208,21 @@ Focused 1M regression checks after the public API additions:
 | `snapshot_loaded_check_direct/1m` | 1M org rules | `[2.9807 us, 2.9895 us, 3.0075 us]` | passes <= 10 us; change within noise |
 | `snapshot_trusted_loaded_check_direct/1m` | 1M org rules | `[3.0595 us, 3.0873 us, 3.1159 us]` | passes <= 10 us; no detected regression |
 
+## 3.6 Concurrent Runtime Benchmarks
+
+[20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md) adds a mixed
+read/write benchmark suite. The first implementation records evidence rather than enforcing hard
+gates because write throughput depends heavily on caller batching and tenant partitioning.
+
+| Operation | Dataset | Target |
+| --- | --- | ---: |
+| `concurrent_runtime/read_heavy_light_write` | 100k base + small batches | record read ops/s and write p95 |
+| `concurrent_runtime/read_heavy_medium_write_unbatched` | 100k base + single writes | record read ops/s and write p95 |
+| `concurrent_runtime/read_heavy_medium_write_batched` | same logical writes batched by 100 | record read ops/s and write p95 |
+| `concurrent_runtime/read_heavy_heavy_write_unbatched` | 100k base + sustained single writes | record read ops/s and write p95 |
+| `concurrent_runtime/read_heavy_heavy_write_batched` | same logical writes batched by 100 or 1k | record read ops/s and write p95 |
+| `concurrent_runtime/tenant_sharded_heavy_write` | same logical write volume split across tenants | record aggregate write ops/s |
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.
@@ -220,6 +235,8 @@ Focused 1M regression checks after the public API additions:
 - No compatibility tuple-store mirror after schema publication.
 - No `BTreeSet` posting lists in the compact store.
 - No hot-path materialization of owned `Relationship` values during `check`.
+- No service-level `RwLock` on public read APIs after [20](./20-concurrent-engine-runtime-design.md).
+- Write throughput guidance must distinguish unbatched, batched, and tenant-sharded cases.
 
 ## 5. Profiling Rules
 

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -180,33 +180,42 @@ snapshot fast-load gate in § 3.4.
 
 | Operation | Dataset | Measurement | Target status |
 | --- | --- | ---: | --- |
-| `public_api/apply_schema/small` | small schema | `[40.358 us, 40.742 us, 41.332 us]` | recorded baseline |
-| `public_api/replace_schema/small` | small schema | `[40.574 us, 41.285 us, 42.260 us]` | recorded baseline |
-| `public_api/delete_relation/small` | small schema | `[2.7558 us, 2.8226 us, 2.8841 us]` | recorded baseline |
-| `public_api/delete_namespace/small` | small schema | `[2.3846 us, 2.4320 us, 2.4550 us]` | recorded baseline |
-| `public_api/check/100k` | 100k org rules | `[2.8479 us, 2.8662 us, 2.8904 us]` | passes <= 10 us |
-| `public_api/expand/100k` | 100k org rules | `[4.6743 us, 4.7234 us, 4.8001 us]` | recorded baseline |
-| `public_api/lookup_resources/100k` | 100k org rules | `[3.2315 ms, 3.2529 ms, 3.2751 ms]` | passes <= 10 ms |
-| `public_api/lookup_subjects/100k` | 100k org rules | `[6.4236 us, 6.4700 us, 6.5226 us]` | passes <= 10 ms |
-| `public_api/lookup_permissions/100k` | 100k org rules | `[15.683 us, 15.799 us, 15.917 us]` | passes <= 250 us |
-| `public_api/lookup_object_permissions/100k` | 100k org rules | `[14.019 us, 14.090 us, 14.148 us]` | passes <= 25 ms |
-| `public_api/write_relationships/1k_batch` | 100k org rules base | `[7.3189 ms, 7.9381 ms, 8.5944 ms]` | recorded baseline |
-| `public_api/apply_policy_text/1k` | 1k org rules | `[1.0222 ms, 1.0575 ms, 1.1059 ms]` | recorded baseline |
-| `public_api/export_policy_text/100k` | 100k org rules | `[41.733 ms, 42.442 ms, 43.150 ms]` | recorded baseline |
-| `public_api/export_policy_files/1k` | 1k org rules | `[1.1863 ms, 1.2307 ms, 1.2975 ms]` | recorded baseline |
-| `public_api/snapshot_save_uncompressed/100k` | 100k org rules | `[49.547 ms, 50.476 ms, 51.422 ms]` | recorded baseline |
-| `public_api/snapshot_load_uncompressed/100k` | 100k org rules | `[52.936 ms, 53.320 ms, 53.705 ms]` | recorded baseline |
-| `public_api/snapshot_save_zstd/100k` | 100k org rules | `[64.139 ms, 64.937 ms, 65.745 ms]` | recorded baseline |
-| `public_api/snapshot_load_zstd/100k` | 100k org rules | `[62.064 ms, 63.144 ms, 64.369 ms]` | recorded baseline |
+| `public_api/apply_schema/small` | small schema | `[64.222 us, 65.553 us, 66.552 us]` | recorded actor-backed API baseline |
+| `public_api/replace_schema/small` | small schema | `[79.059 us, 81.720 us, 83.377 us]` | recorded actor-backed API baseline |
+| `public_api/delete_relation/small` | small schema | `[45.458 us, 47.419 us, 49.389 us]` | recorded actor-backed API baseline |
+| `public_api/delete_namespace/small` | small schema | `[46.536 us, 47.614 us, 49.294 us]` | recorded actor-backed API baseline |
+| `public_api/check/100k` | 100k org rules | `[2.7956 us, 2.8265 us, 2.8615 us]` | passes <= 10 us |
+| `public_api/expand/100k` | 100k org rules | `[4.6261 us, 4.6535 us, 4.7004 us]` | recorded baseline |
+| `public_api/lookup_resources/100k` | 100k org rules | `[3.2256 ms, 3.2559 ms, 3.2761 ms]` | passes <= 10 ms |
+| `public_api/lookup_subjects/100k` | 100k org rules | `[6.3363 us, 6.4295 us, 6.4977 us]` | passes <= 10 ms |
+| `public_api/lookup_permissions/100k` | 100k org rules | `[15.554 us, 15.681 us, 15.921 us]` | passes <= 250 us |
+| `public_api/lookup_object_permissions/100k` | 100k org rules | `[13.676 us, 13.794 us, 13.928 us]` | passes <= 25 ms |
+| `public_api/write_relationships/1k_batch` | 100k org rules base | `[7.3734 ms, 7.9690 ms, 8.5949 ms]` | recorded baseline |
+| `public_api/apply_policy_text/1k` | 1k org rules | `[1.2749 ms, 1.3526 ms, 1.4315 ms]` | recorded baseline |
+| `public_api/export_policy_text/100k` | 100k org rules | `[38.939 ms, 39.808 ms, 40.893 ms]` | recorded baseline |
+| `public_api/export_policy_files/1k` | 1k org rules | `[1.0172 ms, 1.0568 ms, 1.0931 ms]` | recorded baseline |
+| `public_api/snapshot_save_uncompressed/100k` | 100k org rules | `[47.025 ms, 47.823 ms, 48.712 ms]` | recorded baseline |
+| `public_api/snapshot_load_uncompressed/100k` | 100k org rules | `[50.558 ms, 51.390 ms, 52.279 ms]` | recorded baseline |
+| `public_api/snapshot_save_zstd/100k` | 100k org rules | `[62.498 ms, 63.345 ms, 64.432 ms]` | recorded baseline |
+| `public_api/snapshot_load_zstd/100k` | 100k org rules | `[60.120 ms, 60.494 ms, 60.797 ms]` | recorded baseline |
 
 Focused 1M regression checks after the public API additions:
 
 | Operation | Dataset | Measurement | Target status |
 | --- | --- | ---: | --- |
-| `snapshot_load_compact/1m` full mode | 1M org rules | `[574.45 ms, 578.91 ms, 583.77 ms]` | passes <= 700 ms; no detected regression |
-| `snapshot_load_trusted_fast/1m` | 1M org rules | `[138.30 ms, 139.35 ms, 140.46 ms]` | passes <= 200 ms; improved on this run |
-| `snapshot_loaded_check_direct/1m` | 1M org rules | `[2.9807 us, 2.9895 us, 3.0075 us]` | passes <= 10 us; change within noise |
-| `snapshot_trusted_loaded_check_direct/1m` | 1M org rules | `[3.0595 us, 3.0873 us, 3.1159 us]` | passes <= 10 us; no detected regression |
+| `snapshot_build_from_relationships/1m` | 1M org rules | `[2.7622 s, 2.7858 s, 2.8144 s]` | recorded default full-build baseline |
+| `snapshot_save_uncompressed/1m` | 1M org rules | `[541.60 ms, 555.85 ms, 569.02 ms]` | passes <= 1.5 s |
+| `snapshot_load_compact/1m` full mode | 1M org rules | `[555.68 ms, 559.30 ms, 563.48 ms]` | passes <= 700 ms; no detected regression |
+| `snapshot_load_trusted_fast/1m` | 1M org rules | `[135.78 ms, 137.06 ms, 138.67 ms]` | passes <= 200 ms |
+| `snapshot_loaded_check_direct/1m` | 1M org rules | `[3.0067 us, 3.0236 us, 3.0453 us]` | passes <= 10 us |
+| `snapshot_loaded_check_inherited/1m` | 1M org rules | `[7.1645 us, 7.2265 us, 7.2778 us]` | passes <= 25 us |
+| `snapshot_loaded_lookup_resources/1m` | 1M org rules | `[3.8731 ms, 4.0003 ms, 4.2153 ms]` | passes <= 10 ms |
+| `snapshot_file_size/1m` | 1M org rules | `124,422,241 bytes` | recorded v2 size |
+| `snapshot_load_peak_rss/1m` | 1M org rules | `436,076,544-byte max RSS; 404,849,384-byte peak footprint` | passes <= 1.25x loaded RSS |
+| `snapshot_save_zstd/1m` | 1M org rules | `[641.69 ms, 644.70 ms, 647.67 ms]` | distribution-size baseline |
+| `snapshot_load_zstd/1m` | 1M org rules | `[625.35 ms, 628.92 ms, 632.45 ms]` | direct compressed-load baseline |
+| `snapshot_file_size_zstd/1m` | 1M org rules | `33,162,371 bytes` | 26.7% of raw `.szsnap` |
+| `org_authorization/1m_rules/check_denied_exclusion` | 1M org rules | `[981.46 ns, 990.13 ns, 995.71 ns]` | benefits from plain-exclusion short-circuit |
 
 ## 3.6 Concurrent Runtime Benchmarks
 
@@ -223,6 +232,46 @@ gates because write throughput depends heavily on caller batching and tenant par
 | `concurrent_runtime/read_heavy_heavy_write_batched` | same logical writes batched by 100 or 1k | record read ops/s and write p95 |
 | `concurrent_runtime/tenant_sharded_heavy_write` | same logical write volume split across tenants | record aggregate write ops/s |
 
+2026-05-23 evidence:
+
+| Scenario | Read ops/s | Write calls/s | Logical writes/s | Write p95 us |
+| --- | ---: | ---: | ---: | ---: |
+| `concurrent_runtime/read_heavy_light_write_batched` | 5,614,038 | 32 | 1,024 | 887 |
+| `concurrent_runtime/read_heavy_medium_write_unbatched` | 5,920,998 | 1,906 | 1,906 | 1,191 |
+| `concurrent_runtime/read_heavy_medium_write_batched` | 5,807,822 | 742 | 94,976 | 2,663 |
+| `concurrent_runtime/read_heavy_heavy_write_unbatched` | 5,688,228 | 3,908 | 3,908 | 2,635 |
+| `concurrent_runtime/read_heavy_heavy_write_batched` | 5,925,860 | 874 | 111,872 | 9,921 |
+| `concurrent_runtime/tenant_sharded_heavy_write_batched` | 7,816,622 | 3,274 | 419,072 | 2,753 |
+
+## 3.7 Real-World Authorization Benchmarks
+
+The synthetic org benchmark remains the historical trend line for compact storage and snapshot
+load. It is intentionally stable, but it over-represents a small set of hot objects and users. The
+`realworld_authorization` benchmark adds a larger SaaS collaboration sample with:
+
+- 128 tenants and workspace/project/folder/doc resources.
+- group membership, direct users, inherited viewers/editors, auditors, owners, and deny lists.
+- `check`, `lookup_resources`, `lookup_subjects`, `lookup_permissions`,
+  `lookup_object_permissions`, `expand`, mixed-read, snapshot-load, and snapshot-size measurements.
+
+2026-05-23 1M-rule evidence after the plain-exclusion short-circuit optimization:
+
+| Operation | Dataset | Measurement | Target status |
+| --- | --- | ---: | --- |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | 1M realworld rules | `[17.428 us, 17.608 us, 17.852 us]` | recorded realistic inherited baseline |
+| `realworld_authorization/1m_rules/check_doc_direct_user` | 1M realworld rules | `[3.7781 us, 3.8040 us, 3.8441 us]` | recorded direct baseline |
+| `realworld_authorization/1m_rules/check_doc_denied_by_ban` | 1M realworld rules | `[1.1511 us, 1.1627 us, 1.1735 us]` | fixed from pre-optimization ~607 us |
+| `realworld_authorization/1m_rules/check_doc_project_editor` | 1M realworld rules | `[6.3356 us, 6.3913 us, 6.4308 us]` | recorded editor inheritance baseline |
+| `realworld_authorization/1m_rules/lookup_resources_target_user` | 1M realworld rules | `[6.2352 us, 6.2939 us, 6.3217 us]` | recorded bounded lookup baseline |
+| `realworld_authorization/1m_rules/lookup_subjects_shared_doc` | 1M realworld rules | `[11.500 us, 11.581 us, 11.657 us]` | recorded subject lookup baseline |
+| `realworld_authorization/1m_rules/lookup_permissions_shared_doc` | 1M realworld rules | `[12.862 us, 13.015 us, 13.147 us]` | recorded permission enumeration baseline |
+| `realworld_authorization/1m_rules/lookup_object_permissions_shared_doc` | 1M realworld rules | `[28.118 us, 28.645 us, 29.035 us]` | recorded object audit baseline |
+| `realworld_authorization/1m_rules/expand_shared_doc` | 1M realworld rules | `[2.7888 us, 2.8134 us, 2.8311 us]` | recorded expand baseline |
+| `realworld_authorization/1m_rules/mixed_read_workload` | 1M realworld rules | `[63.188 us, 63.394 us, 63.577 us]` | fixed from pre-optimization ~679 us |
+| `realworld_authorization/1m_rules/snapshot_load_compact` | 1M realworld rules | `[557.61 ms, 560.65 ms, 563.14 ms]` | consistent with org 1M full-load gate |
+| `realworld_authorization/1m_rules/snapshot_load_trusted_fast` | 1M realworld rules | `[136.47 ms, 137.53 ms, 138.62 ms]` | passes <= 200 ms trusted gate |
+| `realworld_authorization/1m_rules/snapshot_file_size` | 1M realworld rules | `123,983,263 bytes` | comparable to org 1M artifact |
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.
@@ -237,6 +286,8 @@ gates because write throughput depends heavily on caller batching and tenant par
 - No hot-path materialization of owned `Relationship` values during `check`.
 - No service-level `RwLock` on public read APIs after [20](./20-concurrent-engine-runtime-design.md).
 - Write throughput guidance must distinguish unbatched, batched, and tenant-sharded cases.
+- Real-world benchmark coverage must include deny-list, inheritance, group userset, and audit helper
+  cases; synthetic hot-path benchmarks alone are not sufficient evidence.
 
 ## 5. Profiling Rules
 

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -272,6 +272,30 @@ load. It is intentionally stable, but it over-represents a small set of hot obje
 | `realworld_authorization/1m_rules/snapshot_load_trusted_fast` | 1M realworld rules | `[136.47 ms, 137.53 ms, 138.62 ms]` | passes <= 200 ms trusted gate |
 | `realworld_authorization/1m_rules/snapshot_file_size` | 1M realworld rules | `123,983,263 bytes` | comparable to org 1M artifact |
 
+## 3.8 Structural Performance Optimization Targets
+
+[21-performance-optimization-design.md](./21-performance-optimization-design.md) turns the
+post-M10 performance review into explicit gates. The implementation must first record 1M baselines
+for every new `perf_optimization` filter before claiming an improvement.
+
+| Area | Benchmark | Target |
+| --- | --- | ---: |
+| prepared check / ID-native eval | `perf_optimization/check_prepared_1m` | no public check regression; allocation count lower than baseline |
+| realistic inherited read | `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | >= 10% improvement or profile-backed recalibration |
+| realistic mixed read | `realworld_authorization/1m_rules/mixed_read_workload` | upper estimate <= 55 us |
+| streaming lookup | `perf_optimization/lookup_subjects_streaming_1m` and `perf_optimization/lookup_resources_streaming_1m` | no latency regression; lower allocation count |
+| full snapshot load | `snapshot_load_compact/1m` | upper estimate <= 450 ms after loader optimization |
+| load-time RSS | `snapshot_load_peak_rss/1m` | max RSS <= 400 MiB |
+| trusted fast load | `snapshot_load_trusted_fast/1m` | upper estimate <= 200 ms |
+| single write over 1M base | `perf_optimization/write_single_touch_1m` | p95 improves >= 3x versus pre-change 1M baseline |
+| mixed batch write over 1M base | `perf_optimization/write_mixed_batch_1m` | p95 improves >= 3x versus pre-change 1M baseline |
+| read-heavy heavy writes | `perf_optimization/read_heavy_heavy_write_batched_1m` | read throughput no > 5% regression; write p95 improves >= 2x |
+| index profiles | `snapshot_file_size_check_only/1m` plus RSS equivalent | >= 20% reduction versus `Full` |
+
+The hard <= 200 ms target is intentionally scoped to trusted artifacts. A default full loader that
+continues to prove hostile-file row and index semantics at startup is not expected to hit <= 200 ms
+without changing the trust boundary.
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.
@@ -288,6 +312,9 @@ load. It is intentionally stable, but it over-represents a small set of hot obje
 - Write throughput guidance must distinguish unbatched, batched, and tenant-sharded cases.
 - Real-world benchmark coverage must include deny-list, inheritance, group userset, and audit helper
   cases; synthetic hot-path benchmarks alone are not sufficient evidence.
+- No full relationship-store clone per successful write after [21](./21-performance-optimization-design.md) Phase 12.4.
+- Index-profile optimizations must return typed unsupported-operation errors instead of silently
+  falling back to full scans.
 
 ## 5. Profiling Rules
 
@@ -302,4 +329,5 @@ load. It is intentionally stable, but it over-represents a small set of hot obje
 - <- Depends on: [12-relationship-store-design.md](./12-relationship-store-design.md), [14-evaluation-engine-design.md](./14-evaluation-engine-design.md), [60-crates-features-design.md](./60-crates-features-design.md)
 - -> Consumed by: [72-testing-verification-plan.md](./72-testing-verification-plan.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
 - Memory layout: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md)
+- Performance optimization roadmap: [21-performance-optimization-design.md](./21-performance-optimization-design.md)
 - Related research: [../docs/research/study-spicedb.md § Query Filters and Indexes](../docs/research/study-spicedb.md#query-filters-and-indexes)

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -154,6 +154,60 @@ benchmarks must still satisfy the loaded-query budgets in § 3.2.
 | `snapshot_trusted_loaded_check_inherited/1m` | 1M org rules | `[7.2171 us, 7.2732 us, 7.3198 us]` | passes <= 25 us |
 | `snapshot_trusted_loaded_lookup_resources/1m` | 1M org rules | `[3.8150 ms, 3.9764 ms, 4.1401 ms]` | passes <= 10 ms |
 
+## 3.5 Public API Completeness Benchmarks
+
+[19-public-api-completeness-design.md](./19-public-api-completeness-design.md) adds a public API
+benchmark harness that measures the crate-facing surface, including zstd snapshot wrappers and
+policy text export.
+
+| Operation | Dataset | Target |
+| --- | --- | ---: |
+| `public_api/check/100k` | 100k org rules | Criterion upper estimate <= 10 us |
+| `public_api/expand/100k` | 100k org rules | recorded baseline |
+| `public_api/lookup_resources/100k` | 100k org rules | Criterion upper estimate <= 10 ms |
+| `public_api/lookup_subjects/100k` | 100k org rules | Criterion upper estimate <= 10 ms |
+| `public_api/lookup_permissions/100k` | 100k org rules | Criterion upper estimate <= 250 us |
+| `public_api/lookup_object_permissions/100k` | 100k org rules | Criterion upper estimate <= 25 ms |
+| `public_api/write_relationships/1k_batch` | 100k org rules base | recorded baseline |
+| `public_api/export_policy_text/100k` | 100k org rules | recorded baseline |
+| `public_api/snapshot_save_zstd/100k` | 100k org rules | recorded baseline |
+| `public_api/snapshot_load_zstd/100k` | 100k org rules | recorded baseline |
+
+The zstd numbers describe storage/distribution tradeoffs. They do not replace the trusted raw
+snapshot fast-load gate in § 3.4.
+
+2026-05-23 evidence:
+
+| Operation | Dataset | Measurement | Target status |
+| --- | --- | ---: | --- |
+| `public_api/apply_schema/small` | small schema | `[40.358 us, 40.742 us, 41.332 us]` | recorded baseline |
+| `public_api/replace_schema/small` | small schema | `[40.574 us, 41.285 us, 42.260 us]` | recorded baseline |
+| `public_api/delete_relation/small` | small schema | `[2.7558 us, 2.8226 us, 2.8841 us]` | recorded baseline |
+| `public_api/delete_namespace/small` | small schema | `[2.3846 us, 2.4320 us, 2.4550 us]` | recorded baseline |
+| `public_api/check/100k` | 100k org rules | `[2.8479 us, 2.8662 us, 2.8904 us]` | passes <= 10 us |
+| `public_api/expand/100k` | 100k org rules | `[4.6743 us, 4.7234 us, 4.8001 us]` | recorded baseline |
+| `public_api/lookup_resources/100k` | 100k org rules | `[3.2315 ms, 3.2529 ms, 3.2751 ms]` | passes <= 10 ms |
+| `public_api/lookup_subjects/100k` | 100k org rules | `[6.4236 us, 6.4700 us, 6.5226 us]` | passes <= 10 ms |
+| `public_api/lookup_permissions/100k` | 100k org rules | `[15.683 us, 15.799 us, 15.917 us]` | passes <= 250 us |
+| `public_api/lookup_object_permissions/100k` | 100k org rules | `[14.019 us, 14.090 us, 14.148 us]` | passes <= 25 ms |
+| `public_api/write_relationships/1k_batch` | 100k org rules base | `[7.3189 ms, 7.9381 ms, 8.5944 ms]` | recorded baseline |
+| `public_api/apply_policy_text/1k` | 1k org rules | `[1.0222 ms, 1.0575 ms, 1.1059 ms]` | recorded baseline |
+| `public_api/export_policy_text/100k` | 100k org rules | `[41.733 ms, 42.442 ms, 43.150 ms]` | recorded baseline |
+| `public_api/export_policy_files/1k` | 1k org rules | `[1.1863 ms, 1.2307 ms, 1.2975 ms]` | recorded baseline |
+| `public_api/snapshot_save_uncompressed/100k` | 100k org rules | `[49.547 ms, 50.476 ms, 51.422 ms]` | recorded baseline |
+| `public_api/snapshot_load_uncompressed/100k` | 100k org rules | `[52.936 ms, 53.320 ms, 53.705 ms]` | recorded baseline |
+| `public_api/snapshot_save_zstd/100k` | 100k org rules | `[64.139 ms, 64.937 ms, 65.745 ms]` | recorded baseline |
+| `public_api/snapshot_load_zstd/100k` | 100k org rules | `[62.064 ms, 63.144 ms, 64.369 ms]` | recorded baseline |
+
+Focused 1M regression checks after the public API additions:
+
+| Operation | Dataset | Measurement | Target status |
+| --- | --- | ---: | --- |
+| `snapshot_load_compact/1m` full mode | 1M org rules | `[574.45 ms, 578.91 ms, 583.77 ms]` | passes <= 700 ms; no detected regression |
+| `snapshot_load_trusted_fast/1m` | 1M org rules | `[138.30 ms, 139.35 ms, 140.46 ms]` | passes <= 200 ms; improved on this run |
+| `snapshot_loaded_check_direct/1m` | 1M org rules | `[2.9807 us, 2.9895 us, 3.0075 us]` | passes <= 10 us; change within noise |
+| `snapshot_trusted_loaded_check_direct/1m` | 1M org rules | `[3.0595 us, 3.0873 us, 3.1159 us]` | passes <= 10 us; no detected regression |
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.

--- a/specs/72-testing-verification-plan.md
+++ b/specs/72-testing-verification-plan.md
@@ -54,6 +54,7 @@ This plan defines how each phase proves correctness, safety, compatibility, and 
 | Snapshot artifact | save/load equivalence, corrupt file rejection, file size, load time, and load-time RSS for [17](./17-compact-snapshot-format-design.md) and trusted fast-load coverage for [18](./18-trusted-fast-snapshot-load-design.md). |
 | Public API completeness | zstd snapshot round trips, policy text import/export, schema replacement/deletion, permission enumeration, and public API benchmarks for [19](./19-public-api-completeness-design.md). |
 | Concurrent runtime | lock-free read acquisition, writer actor lifecycle, failed-write atomicity, concurrent read/write behaviour, tenant isolation, and mixed workload benchmarks for [20](./20-concurrent-engine-runtime-design.md). |
+| Structural performance optimization | prepared-check equivalence, ID-native recursion, streaming lookup, segmented-store properties, index-profile support, snapshot phase timers, and 1M write/read benchmarks for [21](./21-performance-optimization-design.md). |
 
 ## 4. Command Gates
 
@@ -158,6 +159,18 @@ realworld_authorization/1m_rules/check_doc_denied_by_ban
 realworld_authorization/1m_rules/mixed_read_workload
 realworld_authorization/1m_rules/snapshot_load_compact
 realworld_authorization/1m_rules/snapshot_load_trusted_fast
+perf_optimization/writer_submit_queue_full
+perf_optimization/check_prepared_1m
+perf_optimization/lookup_subjects_streaming_1m
+perf_optimization/lookup_resources_streaming_1m
+perf_optimization/write_single_touch_1m
+perf_optimization/write_mixed_batch_1m
+perf_optimization/read_heavy_light_write_1m
+perf_optimization/read_heavy_medium_write_unbatched_1m
+perf_optimization/read_heavy_medium_write_batched_1m
+perf_optimization/read_heavy_heavy_write_unbatched_1m
+perf_optimization/read_heavy_heavy_write_batched_1m
+snapshot_file_size_check_only/1m
 ```
 
 Required corrupt-input tests:
@@ -203,10 +216,35 @@ Required tests for [20](./20-concurrent-engine-runtime-design.md):
 - `ZanzibarTenantShards` returns the same engine for the same tenant, different engines for
   different tenants, and isolates schema/relationship state by tenant.
 
-## 11. Cross-References
+## 11. Structural Performance Optimization Verification
+
+Required tests for [21](./21-performance-optimization-design.md):
+
+- writer submit queue-full behavior does not hold a sender mutex while blocked;
+- full-load lazy uniqueness supports subsequent create/touch/delete and publishes no state on lazy
+  uniqueness failure;
+- prepared-check and ID-native evaluator paths are equivalent to current public `check`, including
+  computed userset, tuple-to-userset, intersection, exclusion, cycles, and depth/fanout errors;
+- lookup internals stream bounded candidates, reuse evaluation context state, and preserve result
+  ordering/limits;
+- segmented store random mutation sequences match a reference `HashSet<Relationship>`;
+- checkpoint boundaries preserve exact-revision tokens and query equivalence;
+- index profiles load/save round trip and return typed unsupported-operation errors for unsupported
+  APIs instead of scanning.
+
+Required benchmark target:
+
+```text
+make bench-perf-optimization
+```
+
+The target must be added when the `perf_optimization` benchmark binary lands.
+
+## 12. Cross-References
 
 - <- Depends on: [70-security-design.md](./70-security-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md)
 - -> Consumed by: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
 - Memory layout: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md)
 - Snapshot artifact format: [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md)
 - Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
+- Performance optimization design: [21-performance-optimization-design.md](./21-performance-optimization-design.md)

--- a/specs/72-testing-verification-plan.md
+++ b/specs/72-testing-verification-plan.md
@@ -52,6 +52,7 @@ This plan defines how each phase proves correctness, safety, compatibility, and 
 | Performance | criterion benchmarks for budgets in [71](./71-performance-budgets-design.md). |
 | Memory | peak RSS checks for compact relationship store budgets in [16](./16-compact-relationship-store-design.md). |
 | Snapshot artifact | save/load equivalence, corrupt file rejection, file size, load time, and load-time RSS for [17](./17-compact-snapshot-format-design.md) and trusted fast-load coverage for [18](./18-trusted-fast-snapshot-load-design.md). |
+| Public API completeness | zstd snapshot round trips, policy text import/export, schema replacement/deletion, permission enumeration, and public API benchmarks for [19](./19-public-api-completeness-design.md). |
 
 ## 4. Command Gates
 
@@ -134,6 +135,14 @@ snapshot_trusted_loaded_check_inherited/1m
 snapshot_trusted_loaded_lookup_resources/1m
 snapshot_load_peak_rss/1m
 snapshot_file_size/1m
+public_api/check/100k
+public_api/lookup_resources/100k
+public_api/lookup_subjects/100k
+public_api/lookup_permissions/100k
+public_api/lookup_object_permissions/100k
+public_api/export_policy_text/100k
+public_api/snapshot_save_zstd/100k
+public_api/snapshot_load_zstd/100k
 ```
 
 Required corrupt-input tests:
@@ -154,9 +163,23 @@ snapshot built from the same relationship set. Trusted fast-load snapshots must 
 that subsequent create/touch/delete writes preserve relationship uniqueness semantics after the lazy
 uniqueness index is built.
 
-## 9. Cross-References
+## 9. Public API Completeness Verification
+
+Required tests for [19](./19-public-api-completeness-design.md):
+
+- raw and zstd snapshot artifacts round trip through both `ZanzibarService` and `ZanzibarEngine`;
+- zstd load rejects decompressed payloads beyond `SnapshotLoadOptions::max_file_bytes`;
+- `PolicyText` import/export preserves check, expand, lookup, and permission enumeration behavior;
+- exported policy files are deterministic, sorted, and grouped by resource namespace;
+- schema replacement, namespace deletion, and relation deletion publish revisions on success and
+  leave the prior state observable after failed deletion;
+- `lookup_permissions` and `lookup_object_permissions` cover direct, computed userset,
+  tuple-to-userset, and exclusion behavior.
+
+## 10. Cross-References
 
 - <- Depends on: [70-security-design.md](./70-security-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md)
 - -> Consumed by: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
 - Memory layout: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md)
 - Snapshot artifact format: [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md)
+- Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)

--- a/specs/72-testing-verification-plan.md
+++ b/specs/72-testing-verification-plan.md
@@ -136,6 +136,9 @@ snapshot_trusted_loaded_check_inherited/1m
 snapshot_trusted_loaded_lookup_resources/1m
 snapshot_load_peak_rss/1m
 snapshot_file_size/1m
+snapshot_save_zstd/1m
+snapshot_load_zstd/1m
+snapshot_file_size_zstd/1m
 public_api/check/100k
 public_api/lookup_resources/100k
 public_api/lookup_subjects/100k
@@ -150,6 +153,11 @@ concurrent_runtime/read_heavy_medium_write_batched
 concurrent_runtime/read_heavy_heavy_write_unbatched
 concurrent_runtime/read_heavy_heavy_write_batched
 concurrent_runtime/tenant_sharded_heavy_write
+realworld_authorization/1m_rules/check_doc_inherited_workspace_member
+realworld_authorization/1m_rules/check_doc_denied_by_ban
+realworld_authorization/1m_rules/mixed_read_workload
+realworld_authorization/1m_rules/snapshot_load_compact
+realworld_authorization/1m_rules/snapshot_load_trusted_fast
 ```
 
 Required corrupt-input tests:

--- a/specs/72-testing-verification-plan.md
+++ b/specs/72-testing-verification-plan.md
@@ -47,12 +47,13 @@ This plan defines how each phase proves correctness, safety, compatibility, and 
 | Revision consistency | latest read, exact read, expired token, wrong datastore ID, schema hash mismatch. |
 | Evaluation | every expression variant, cross-namespace usersets, recursion cycles, depth exceeded, fanout limit. |
 | Expand/lookup | shared evaluator semantics, duplicate suppression, result limits. |
-| Compatibility | existing tests pass through `ZanzibarService` facade. |
+| Public runtime | existing tests pass through `ZanzibarEngine`; no legacy mutable facade remains public. |
 | Security | no panics on malformed external input, no unchecked indexing in boundary modules. |
 | Performance | criterion benchmarks for budgets in [71](./71-performance-budgets-design.md). |
 | Memory | peak RSS checks for compact relationship store budgets in [16](./16-compact-relationship-store-design.md). |
 | Snapshot artifact | save/load equivalence, corrupt file rejection, file size, load time, and load-time RSS for [17](./17-compact-snapshot-format-design.md) and trusted fast-load coverage for [18](./18-trusted-fast-snapshot-load-design.md). |
 | Public API completeness | zstd snapshot round trips, policy text import/export, schema replacement/deletion, permission enumeration, and public API benchmarks for [19](./19-public-api-completeness-design.md). |
+| Concurrent runtime | lock-free read acquisition, writer actor lifecycle, failed-write atomicity, concurrent read/write behaviour, tenant isolation, and mixed workload benchmarks for [20](./20-concurrent-engine-runtime-design.md). |
 
 ## 4. Command Gates
 
@@ -143,6 +144,12 @@ public_api/lookup_object_permissions/100k
 public_api/export_policy_text/100k
 public_api/snapshot_save_zstd/100k
 public_api/snapshot_load_zstd/100k
+concurrent_runtime/read_heavy_light_write
+concurrent_runtime/read_heavy_medium_write_unbatched
+concurrent_runtime/read_heavy_medium_write_batched
+concurrent_runtime/read_heavy_heavy_write_unbatched
+concurrent_runtime/read_heavy_heavy_write_batched
+concurrent_runtime/tenant_sharded_heavy_write
 ```
 
 Required corrupt-input tests:
@@ -167,7 +174,7 @@ uniqueness index is built.
 
 Required tests for [19](./19-public-api-completeness-design.md):
 
-- raw and zstd snapshot artifacts round trip through both `ZanzibarService` and `ZanzibarEngine`;
+- raw and zstd snapshot artifacts round trip through `ZanzibarEngine`;
 - zstd load rejects decompressed payloads beyond `SnapshotLoadOptions::max_file_bytes`;
 - `PolicyText` import/export preserves check, expand, lookup, and permission enumeration behavior;
 - exported policy files are deterministic, sorted, and grouped by resource namespace;
@@ -176,7 +183,19 @@ Required tests for [19](./19-public-api-completeness-design.md):
 - `lookup_permissions` and `lookup_object_permissions` cover direct, computed userset,
   tuple-to-userset, and exclusion behavior.
 
-## 10. Cross-References
+## 10. Concurrent Runtime Verification
+
+Required tests for [20](./20-concurrent-engine-runtime-design.md):
+
+- public API no longer exports the legacy mutable service facade;
+- latest read APIs work while a writer actor is processing write traffic;
+- failed relationship, schema, and policy writes publish no state;
+- exact consistency tokens remain valid for retained snapshots and reject foreign tenant tokens;
+- actor shutdown/drop does not leak writer threads in tests;
+- `ZanzibarTenantShards` returns the same engine for the same tenant, different engines for
+  different tenants, and isolates schema/relationship state by tenant.
+
+## 11. Cross-References
 
 - <- Depends on: [70-security-design.md](./70-security-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md)
 - -> Consumed by: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md), [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)

--- a/specs/90-local-engine-roadmap.md
+++ b/specs/90-local-engine-roadmap.md
@@ -138,6 +138,24 @@ Exit criteria:
 - `snapshot_load_trusted_fast/1m` Criterion upper estimate <= 200 ms with trusted fast-load and external integrity
 - trusted loaded direct, inherited, and lookup latency budgets in [71](./71-performance-budgets-design.md) pass
 
+### M9 - Complete Public API Surface
+
+User-visible outcome: applications can use Simple Zanzibar as a complete local policy package:
+load/save raw or zstd snapshots, import/export reviewable policy text, replace/delete schema
+policy, and answer permission-audit queries without hand-enumerating schema relations.
+
+Specs touched: [15](./15-public-api-design.md), [19](./19-public-api-completeness-design.md), [71](./71-performance-budgets-design.md), [72](./72-testing-verification-plan.md).
+
+Exit criteria:
+
+- raw and zstd snapshot save/load APIs round trip equivalent services
+- `PolicyText` import/export round trips schema and relationships with deterministic sorted output
+- `export_policy_files` writes `schema.zed` and grouped relationship files suitable for review
+- schema replacement, namespace deletion, and relation deletion publish revisions only when existing relationships remain valid
+- `lookup_permissions` and `lookup_object_permissions` return stable sorted audit results
+- public API benchmarks record check, lookup, permission enumeration, policy export, and zstd snapshot costs
+- full build, test, fmt, clippy, audit, and deny gates pass
+
 ## 3. Calendar Shape
 
 One experienced Rust developer:
@@ -151,6 +169,7 @@ One experienced Rust developer:
 - M6: 2 to 3 weeks
 - M7: 2 to 3 weeks
 - M8: 1 week
+- M9: 1 week
 
 Total through M5: 8.5 to 11 weeks, assuming no persistent backend and no caveats.
 
@@ -159,6 +178,8 @@ Total through M6: 10.5 to 14 weeks.
 Total through M7: 12.5 to 17 weeks.
 
 Total through M8: 13.5 to 18 weeks.
+
+Total through M9: 14.5 to 19 weeks.
 
 ## 4. Cross-References
 

--- a/specs/90-local-engine-roadmap.md
+++ b/specs/90-local-engine-roadmap.md
@@ -2,7 +2,7 @@
 
 Status: draft v1
 Owner: Simple Zanzibar
-Last updated: 2026-05-23
+Last updated: 2026-05-24
 
 ## 1. Principles
 
@@ -180,6 +180,34 @@ Exit criteria:
 - benchmark results are posted to the PR comment
 - full build, test, fmt, strict clippy, docs, audit, and deny gates pass
 
+### M11 - Structural Performance Optimization
+
+User-visible outcome: the engine keeps the current complete public API while lowering write
+amplification, reducing evaluator/lookup allocation, improving safe full snapshot load, preserving
+the trusted <= 200 ms path, and offering explicit lower-memory index profiles for check-heavy
+deployments.
+
+Specs touched: [14](./14-evaluation-engine-design.md), [16](./16-compact-relationship-store-design.md),
+[17](./17-compact-snapshot-format-design.md), [18](./18-trusted-fast-snapshot-load-design.md),
+[20](./20-concurrent-engine-runtime-design.md), [21](./21-performance-optimization-design.md),
+[71](./71-performance-budgets-design.md), [72](./72-testing-verification-plan.md).
+
+Exit criteria:
+
+- writer submit path no longer holds a mutex while blocked on a full queue
+- public read behavior remains equivalent while prepared checks and ID-native recursive evaluation
+  reduce hot-path allocation
+- lookup internals stream bounded candidates and reuse evaluation context state
+- full snapshot load phase timers are recorded and `snapshot_load_compact/1m` upper estimate is
+  <= 450 ms or recalibrated with profile evidence
+- `snapshot_load_trusted_fast/1m` remains <= 200 ms
+- segmented write-store publication avoids full-store clone per successful write and improves
+  1M-base write p95 by the gates in [21](./21-performance-optimization-design.md)
+- index profiles support `Full`, `CheckOnly`, and `CheckAndObjectAudit` with typed errors for
+  unsupported operations
+- performance results are posted to the PR comment
+- full build, test, fmt, strict clippy, docs, audit, and deny gates pass
+
 ## 3. Calendar Shape
 
 One experienced Rust developer:
@@ -195,6 +223,7 @@ One experienced Rust developer:
 - M8: 1 week
 - M9: 1 week
 - M10: 1.5 to 2 weeks
+- M11: 3 to 5 weeks
 
 Total through M5: 8.5 to 11 weeks, assuming no persistent backend and no caveats.
 
@@ -208,7 +237,10 @@ Total through M9: 14.5 to 19 weeks.
 
 Total through M10: 16 to 21 weeks.
 
+Total through M11: 19 to 26 weeks.
+
 ## 4. Cross-References
 
 - Paired engineer plan: [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
 - Verification gates: [72-testing-verification-plan.md](./72-testing-verification-plan.md)
+- Performance optimization design: [21-performance-optimization-design.md](./21-performance-optimization-design.md)

--- a/specs/90-local-engine-roadmap.md
+++ b/specs/90-local-engine-roadmap.md
@@ -156,6 +156,30 @@ Exit criteria:
 - public API benchmarks record check, lookup, permission enumeration, policy export, and zstd snapshot costs
 - full build, test, fmt, clippy, audit, and deny gates pass
 
+### M10 - Concurrent Runtime and Tenant Shards
+
+User-visible outcome: applications use `ZanzibarEngine` as the only public runtime. Read APIs no
+longer take a service-level lock, writes flow through a single writer actor optimized for caller
+batches, and multi-tenant applications can shard state across independent tenant engines.
+
+Specs touched: [13](./13-revision-consistency-design.md), [15](./15-public-api-design.md),
+[20](./20-concurrent-engine-runtime-design.md), [71](./71-performance-budgets-design.md),
+[72](./72-testing-verification-plan.md).
+
+Exit criteria:
+
+- the legacy mutable facade is removed from the public API, examples, tests, and benchmarks
+- latest check/expand/lookup/export/snapshot-save paths clone immutable `EngineState` through
+  `ArcSwapOption` and do not acquire a read lock
+- relationship, schema, and policy writes are serialized by a bounded single writer actor
+- failed writes publish no snapshot and preserve exact-token semantics
+- tenant shard manager routes existing tenant lookups without locking and isolates revisions/tokens
+  per tenant
+- concurrent runtime benchmarks cover read-heavy/light-write, read-heavy/medium-write
+  unbatched/batched, read-heavy/heavy-write unbatched/batched, and tenant-sharded write load
+- benchmark results are posted to the PR comment
+- full build, test, fmt, strict clippy, docs, audit, and deny gates pass
+
 ## 3. Calendar Shape
 
 One experienced Rust developer:
@@ -170,6 +194,7 @@ One experienced Rust developer:
 - M7: 2 to 3 weeks
 - M8: 1 week
 - M9: 1 week
+- M10: 1.5 to 2 weeks
 
 Total through M5: 8.5 to 11 weeks, assuming no persistent backend and no caveats.
 
@@ -180,6 +205,8 @@ Total through M7: 12.5 to 17 weeks.
 Total through M8: 13.5 to 18 weeks.
 
 Total through M9: 14.5 to 19 weeks.
+
+Total through M10: 16 to 21 weeks.
 
 ## 4. Cross-References
 

--- a/specs/91-local-engine-impl-plan.md
+++ b/specs/91-local-engine-impl-plan.md
@@ -53,7 +53,7 @@ Closes M0 foundation.
 | 1.2 | Add schema IR and resolver. | [11](./11-schema-system-design.md) | 1 day |
 | 1.3 | Compile legacy DSL into schema IR. | [11](./11-schema-system-design.md), [15](./15-public-api-design.md) | 1 day |
 | 1.4 | Add schema validator for duplicates and relation references. | [11](./11-schema-system-design.md) | 1.5 days |
-| 1.5 | Wire `ZanzibarService` facade through v2 schema where possible. | [15](./15-public-api-design.md) | 1 day |
+| 1.5 | Wire legacy mutable facade through v2 schema where possible. | [15](./15-public-api-design.md) | 1 day |
 | 1.6 | Add schema/domain tests and doctests. | [72](./72-testing-verification-plan.md) | 1 day |
 
 Exit criteria: M0 roadmap criteria pass.
@@ -230,7 +230,31 @@ Exit criteria:
 - Public API benchmark results are posted to the PR comment.
 - `cargo build --workspace --all-targets`, `cargo test --workspace --all-features`, `cargo +nightly fmt --check`, strict clippy including boundary lints, `cargo audit`, and `cargo deny check` pass.
 
-## 13. Cross-References
+## 13. Phase 11 - Concurrent Runtime and Tenant Shards
+
+Closes M10.
+
+| # | Task | Spec | Effort |
+| --- | --- | --- | --- |
+| 11.1 | Remove public legacy mutable facade and port examples/tests/benches to `ZanzibarEngine`. | [20](./20-concurrent-engine-runtime-design.md), [15](./15-public-api-design.md) | 1 day |
+| 11.2 | Add immutable `EngineState` and move read APIs to `ArcSwapOption<EngineState>`. | [20](./20-concurrent-engine-runtime-design.md), [13](./13-revision-consistency-design.md) | 1 day |
+| 11.3 | Add bounded single writer actor owning mutable writer state and publishing snapshots. | [20](./20-concurrent-engine-runtime-design.md) | 1.5 days |
+| 11.4 | Add actor lifecycle, writer failure, failed-write atomicity, and concurrent read/write tests. | [20](./20-concurrent-engine-runtime-design.md), [72](./72-testing-verification-plan.md) | 1 day |
+| 11.5 | Add `TenantId` and `ZanzibarTenantShards` with lock-free existing-tenant reads. | [20](./20-concurrent-engine-runtime-design.md) | 1 day |
+| 11.6 | Add concurrent runtime Criterion benchmarks for read/write mix, batching, and tenant sharding. | [20](./20-concurrent-engine-runtime-design.md), [71](./71-performance-budgets-design.md) | 1 day |
+| 11.7 | Run full correctness gates and post benchmark evidence to the PR. | [72](./72-testing-verification-plan.md) | 1 day |
+
+Exit criteria:
+
+- M10 roadmap criteria pass.
+- Existing public snapshot, policy, schema, check, expand, lookup, and permission enumeration
+  behavior remains equivalent through `ZanzibarEngine`.
+- `cargo build --workspace --all-targets`, `cargo test --workspace --all-features`,
+  `cargo +nightly fmt --check`, strict clippy including boundary lints,
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `cargo audit`, and
+  `cargo deny check` pass.
+
+## 14. Cross-References
 
 - Stakeholder roadmap: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md)
 - Key decisions: [99-key-decisions.md](./99-key-decisions.md)
@@ -238,3 +262,4 @@ Exit criteria:
 - Compact store design: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md)
 - Compact snapshot format: [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md)
 - Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
+- Concurrent engine runtime: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md)

--- a/specs/91-local-engine-impl-plan.md
+++ b/specs/91-local-engine-impl-plan.md
@@ -208,6 +208,28 @@ Exit criteria:
 - trusted loaded query benchmarks pass the loaded-query budgets.
 - `cargo build --workspace --all-targets`, `cargo test --workspace --all-features`, `cargo +nightly fmt --check`, strict clippy including boundary lints, `cargo audit`, and `cargo deny check` pass.
 
+## 12b. Phase 10 - Public API Completeness
+
+Closes M9.
+
+| # | Task | Spec | Effort |
+| --- | --- | --- | --- |
+| 10.1 | Add zstd snapshot compression options, bounded decompression, and raw/zstd load-save tests. | [19](./19-public-api-completeness-design.md), [17](./17-compact-snapshot-format-design.md), [70](./70-security-design.md) | 1 day |
+| 10.2 | Add `PolicyText`, policy import/export helpers, deterministic file export, and snapshot-from-policy helpers. | [19](./19-public-api-completeness-design.md), [15](./15-public-api-design.md) | 1.5 days |
+| 10.3 | Add schema replacement, namespace deletion, and relation deletion APIs with atomic revalidation. | [19](./19-public-api-completeness-design.md), [11](./11-schema-system-design.md), [13](./13-revision-consistency-design.md) | 1 day |
+| 10.4 | Add `lookup_permissions` and `lookup_object_permissions` request/response APIs on service and engine. | [19](./19-public-api-completeness-design.md), [14](./14-evaluation-engine-design.md), [15](./15-public-api-design.md) | 1 day |
+| 10.5 | Add integration tests for zstd, policy round trips, schema deletion failure atomicity, permission enumeration, and engine wrappers. | [19](./19-public-api-completeness-design.md), [72](./72-testing-verification-plan.md) | 1 day |
+| 10.6 | Add `public_api` Criterion benchmark target and Makefile target; run and publish results. | [19](./19-public-api-completeness-design.md), [71](./71-performance-budgets-design.md) | 1 day |
+
+Exit criteria:
+
+- M9 roadmap criteria pass.
+- Existing snapshot full/trusted validation tests still pass.
+- zstd load applies the configured byte cap to both compressed and decompressed bytes.
+- Policy export/import is deterministic and behaviorally equivalent for check, expand, lookup, and permission enumeration.
+- Public API benchmark results are posted to the PR comment.
+- `cargo build --workspace --all-targets`, `cargo test --workspace --all-features`, `cargo +nightly fmt --check`, strict clippy including boundary lints, `cargo audit`, and `cargo deny check` pass.
+
 ## 13. Cross-References
 
 - Stakeholder roadmap: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md)
@@ -215,3 +237,4 @@ Exit criteria:
 - Verification gates: [72-testing-verification-plan.md](./72-testing-verification-plan.md)
 - Compact store design: [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md)
 - Compact snapshot format: [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md)
+- Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)

--- a/specs/91-local-engine-impl-plan.md
+++ b/specs/91-local-engine-impl-plan.md
@@ -2,7 +2,7 @@
 
 Status: draft v1
 Owner: Simple Zanzibar
-Last updated: 2026-05-23
+Last updated: 2026-05-24
 
 ## 1. Readiness Assessment
 
@@ -186,6 +186,7 @@ The order is correct because:
 - compact storage is valuable only after the full indexed/snapshot/evaluator path exists and benchmark evidence identifies memory as the limiting resource
 - compact snapshot serialization is valuable only after the in-memory compact representation is stable and memory evidence identifies cold load as the next bottleneck
 - trusted fast-load is valuable only after the fully validating snapshot format exists and profiling identifies repeated semantic validation as the dominant cost
+- structural optimization is valuable only after the complete public API and concurrent runtime exist, because otherwise benchmarks would optimize a provisional surface
 
 ## 12a. Phase 9 - Trusted Fast Snapshot Load
 
@@ -254,7 +255,38 @@ Exit criteria:
   `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `cargo audit`, and
   `cargo deny check` pass.
 
-## 14. Cross-References
+## 14. Phase 12 - Structural Performance Optimization
+
+Closes M11.
+
+| # | Task | Spec | Effort |
+| --- | --- | --- | --- |
+| 12.1 | Add `perf_optimization` benchmark harness, 1M write/mixed read baselines, snapshot phase timers, and `bench-perf-optimization` Makefile target. | [21](./21-performance-optimization-design.md), [71](./71-performance-budgets-design.md), [72](./72-testing-verification-plan.md) | 1 day |
+| 12.2 | Remove writer submit mutex blocking, add sorted relation cache, add all-live row fast path, and switch full-load uniqueness to lazy retained state. | [20](./20-concurrent-engine-runtime-design.md), [21](./21-performance-optimization-design.md) | 2 days |
+| 12.3 | Add prepared-check path and ID-native evaluator keys for recursive check, computed userset, and tuple-to-userset. | [14](./14-evaluation-engine-design.md), [21](./21-performance-optimization-design.md) | 3 days |
+| 12.4 | Rework lookup internals to stream bounded candidates and reuse evaluation contexts without changing public response types. | [14](./14-evaluation-engine-design.md), [19](./19-public-api-completeness-design.md), [21](./21-performance-optimization-design.md) | 2 days |
+| 12.5 | Optimize snapshot load/save with fixed section lookup, optional bounded parallel index decode, and streaming writer. | [17](./17-compact-snapshot-format-design.md), [18](./18-trusted-fast-snapshot-load-design.md), [21](./21-performance-optimization-design.md) | 3 days |
+| 12.6 | Introduce internal segmented `StoreView` / `StoreDelta` publication with checkpoint thresholds and exact-revision retention. | [13](./13-revision-consistency-design.md), [16](./16-compact-relationship-store-design.md), [20](./20-concurrent-engine-runtime-design.md), [21](./21-performance-optimization-design.md) | 5 days |
+| 12.7 | Add `IndexProfile::{Full, CheckOnly, CheckAndObjectAudit}` to runtime/snapshot options with typed unsupported-operation errors. | [17](./17-compact-snapshot-format-design.md), [19](./19-public-api-completeness-design.md), [21](./21-performance-optimization-design.md) | 3 days |
+| 12.8 | Run full correctness gates, 1M perf benchmarks, RSS checks, and post detailed benchmark evidence to the PR. | [71](./71-performance-budgets-design.md), [72](./72-testing-verification-plan.md) | 1 day |
+
+Exit criteria:
+
+- M11 roadmap criteria pass.
+- Public check, expand, lookup, permission enumeration, policy import/export, snapshot load/save,
+  and exact consistency behavior remain equivalent unless an unsupported index profile is explicitly
+  selected.
+- Segmented store property tests pass against a reference relationship set for random mutation
+  sequences and checkpoint boundaries.
+- `snapshot_load_compact/1m`, `snapshot_load_trusted_fast/1m`, `snapshot_load_peak_rss/1m`, 1M
+  read latency, 1M write latency, concurrent runtime, and index-profile size/RSS benchmarks are
+  recorded in [71](./71-performance-budgets-design.md).
+- `cargo build --workspace --all-targets`, `cargo test --workspace --all-features`,
+  `cargo +nightly fmt --check`, strict clippy including boundary lints,
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`, `cargo audit`, and
+  `cargo deny check` pass.
+
+## 15. Cross-References
 
 - Stakeholder roadmap: [90-local-engine-roadmap.md](./90-local-engine-roadmap.md)
 - Key decisions: [99-key-decisions.md](./99-key-decisions.md)
@@ -263,3 +295,4 @@ Exit criteria:
 - Compact snapshot format: [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md)
 - Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
 - Concurrent engine runtime: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md)
+- Performance optimization design: [21-performance-optimization-design.md](./21-performance-optimization-design.md)

--- a/specs/99-key-decisions.md
+++ b/specs/99-key-decisions.md
@@ -2,7 +2,7 @@
 
 Status: draft v1
 Owner: Simple Zanzibar
-Last updated: 2026-05-23
+Last updated: 2026-05-24
 
 Each decision is load-bearing. Supersede with a new decision entry rather than silently rewriting history.
 
@@ -246,3 +246,23 @@ Each decision is load-bearing. Supersede with a new decision entry rather than s
   [71-performance-budgets-design.md](./71-performance-budgets-design.md),
   [72-testing-verification-plan.md](./72-testing-verification-plan.md)
 - Date: 2026-05-23
+
+## D21 - Optimize by reusable proofs and deltas before unsafe or weaker defaults
+
+- Context: after M10, measured 1M performance is already good for trusted raw load and reads, but
+  full writes still clone too much state, some evaluator/lookup paths allocate legacy objects, and
+  the default full loader repeats semantic validation on every startup.
+- Alternatives considered: add mmap/unsafe zero-copy, weaken the default full loader, add
+  fine-grained relationship locks, keep clone-on-write and rely only on tenant sharding, or optimize
+  by reusing prior proof and publishing small immutable deltas.
+- Decision: keep safe full validation as the default, preserve the trusted fast-load boundary for
+  <= 200 ms cold starts, remove avoidable hot-path allocation, and replace full-store write cloning
+  with segmented immutable deltas plus checkpointing.
+- Why: this applies the rsync-like principle that unchanged data and already-proven facts should
+  not be recopied or revalidated. It improves write amplification, load time, and memory without
+  changing the security boundary or introducing unsafe code.
+- Pinned by: [21-performance-optimization-design.md](./21-performance-optimization-design.md),
+  [71-performance-budgets-design.md](./71-performance-budgets-design.md),
+  [72-testing-verification-plan.md](./72-testing-verification-plan.md),
+  [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md)
+- Date: 2026-05-24

--- a/specs/99-key-decisions.md
+++ b/specs/99-key-decisions.md
@@ -193,3 +193,37 @@ Each decision is load-bearing. Supersede with a new decision entry rather than s
   [14-evaluation-engine-design.md](./14-evaluation-engine-design.md),
   [71-performance-budgets-design.md](./71-performance-budgets-design.md)
 - Date: 2026-05-23
+
+## D18 - Remove the legacy mutable service facade before API stabilization
+
+- Context: the legacy mutable facade kept early compatibility while the strict engine API matured, but the
+  crate API is not yet stable and the mutable facade now encourages service-level locking and
+  duplicate examples.
+- Alternatives considered: keep the legacy mutable facade indefinitely; hide it behind a `compat` feature;
+  remove it and make `ZanzibarEngine` the only public runtime.
+- Decision: remove the legacy mutable facade from the public API, examples, tests, and benchmarks.
+- Why: the runtime contract should be one coherent engine: lock-free snapshot reads, typed request
+  APIs, actor-backed writes, and policy/snapshot import/export on the same facade. Keeping a second
+  mutable public type would force future compatibility work around a shape we already know is not
+  the intended API.
+- Pinned by: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md),
+  [15-public-api-design.md](./15-public-api-design.md),
+  [72-testing-verification-plan.md](./72-testing-verification-plan.md)
+- Date: 2026-05-23
+
+## D19 - Scale writes by batching and tenant sharding before fine-grained locks
+
+- Context: Relationship writes, preconditions, schema replacement, consistency tokens, and snapshot
+  publication all require a single linearized write order inside one authorization state.
+- Alternatives considered: per-object locks; per-namespace locks; optimistic CAS publish retries;
+  a bounded single writer actor with caller batching; tenant-level sharding.
+- Decision: use a single writer actor per `ZanzibarEngine`, make batch writes the throughput path,
+  and add `ZanzibarTenantShards` for applications with independent tenant authorization states.
+- Why: fine-grained locks would still need a global publish point and would complicate precondition
+  correctness. Batching reduces per-write fixed cost, and tenant sharding moves true independence
+  into separate revision/token spaces instead of pretending one tenant's global revision can be
+  partitioned by object.
+- Pinned by: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md),
+  [13-revision-consistency-design.md](./13-revision-consistency-design.md),
+  [71-performance-budgets-design.md](./71-performance-budgets-design.md)
+- Date: 2026-05-23

--- a/specs/99-key-decisions.md
+++ b/specs/99-key-decisions.md
@@ -227,3 +227,22 @@ Each decision is load-bearing. Supersede with a new decision entry rather than s
   [13-revision-consistency-design.md](./13-revision-consistency-design.md),
   [71-performance-budgets-design.md](./71-performance-budgets-design.md)
 - Date: 2026-05-23
+
+## D20 - Benchmark and optimize realistic deny-list checks
+
+- Context: the stable org benchmark covered direct checks, inherited usersets, lookup, and snapshot
+  load, but it did not exercise a realistic denied-user path where `can_view` subtracts a plain
+  `banned` relation from a deeper allow graph. The new real-world 1M benchmark measured that path at
+  roughly 607 us before optimization.
+- Alternatives considered: keep the benchmark synthetic; require schema authors to order rules
+  differently; always evaluate the exclude side before the base side; use a cheap-expression
+  heuristic.
+- Decision: add `realworld_authorization` benchmarks and evaluate the exclude side first only when
+  it is a cheap plain relation on the current object, such as a direct deny list.
+- Why: `A - B` is semantically denied when `B` is allowed, so a direct deny hit can skip an
+  expensive inherited allow graph. Limiting the reorder to cheap plain relations avoids regressing
+  cases where the base side is cheap and the exclude side is recursive or high-fanout.
+- Pinned by: [14-evaluation-engine-design.md](./14-evaluation-engine-design.md),
+  [71-performance-budgets-design.md](./71-performance-budgets-design.md),
+  [72-testing-verification-plan.md](./72-testing-verification-plan.md)
+- Date: 2026-05-23

--- a/specs/99-key-decisions.md
+++ b/specs/99-key-decisions.md
@@ -157,3 +157,39 @@ Each decision is load-bearing. Supersede with a new decision entry rather than s
   the supply-chain tradeoff visible in code review.
 - Pinned by: [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md), [72-testing-verification-plan.md](./72-testing-verification-plan.md)
 - Date: 2026-05-23
+
+## D16 - Treat zstd as an outer snapshot transport wrapper
+
+- Context: The `.szsnap` v2 payload is already close to the in-memory compact representation and
+  meets the trusted 200 ms raw load target. zstd is valuable for distribution and disk footprint,
+  but decoding it during startup adds CPU and transient memory that should not redefine the raw
+  fast-load contract.
+- Alternatives considered: compress individual `.szsnap` sections; add a new compressed file
+  version; keep compression entirely outside the crate; wrap the raw `.szsnap` bytes in one zstd
+  frame.
+- Decision: add `SnapshotCompression::Zstd` as a public save/load option that compresses or
+  decompresses the entire raw `.szsnap` payload before the existing v2 parser runs.
+- Why: this preserves the stable binary format, keeps corrupt-file validation in one parser, and
+  lets deployments choose between direct compressed load and the faster content-addressed cache
+  pattern of decompress-once then raw trusted fast-load.
+- Pinned by: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md),
+  [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md),
+  [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md)
+- Date: 2026-05-23
+
+## D17 - Add bounded audit helpers instead of an unbounded global permission matrix
+
+- Context: Users need "what permissions does this subject have on this object?" and "who has which
+  permissions on this object?" as public API calls. A full global matrix over every object, subject,
+  and relation would be expensive and easy to misuse in an embedded library.
+- Alternatives considered: require callers to enumerate schema relations manually; add a global
+  audit scan; add object/subject-bounded helpers that compose existing evaluators.
+- Decision: add `lookup_permissions` for one subject/object pair and `lookup_object_permissions`
+  for one object plus one subject type. Both enumerate only the target object's schema relations and
+  reuse the existing `check` / `lookup_subjects` semantics.
+- Why: the helpers cover common product questions while preserving Zanzibar's explicit subject-type
+  lookup boundary and existing evaluator limits.
+- Pinned by: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md),
+  [14-evaluation-engine-design.md](./14-evaluation-engine-design.md),
+  [71-performance-budgets-design.md](./71-performance-budgets-design.md)
+- Date: 2026-05-23

--- a/specs/index.md
+++ b/specs/index.md
@@ -20,11 +20,12 @@ Read the v2 specs in numeric order. The order is also the implementation depende
 | [12-relationship-store-design.md](./12-relationship-store-design.md) | Design | Indexed in-memory relationship store, query filters, write mutations, preconditions. |
 | [13-revision-consistency-design.md](./13-revision-consistency-design.md) | Design | Local revision tokens, snapshot readers, schema hashes, copy-on-write publication. |
 | [14-evaluation-engine-design.md](./14-evaluation-engine-design.md) | Design | Check, expand, lookup, membership algebra, recursion policy, execution context. |
-| [15-public-api-design.md](./15-public-api-design.md) | Design | Crate-facing API, compatibility facade, error mapping, examples. |
+| [15-public-api-design.md](./15-public-api-design.md) | Design | Crate-facing API, error mapping, examples. |
 | [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md) | Design | Compact row storage, identifier interning, `Vec<RowId>` postings, snapshot ownership cleanup, memory targets. |
 | [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md) | Design | Versioned compact snapshot artifact for fast load, bounded load-time RSS, and practical disk size. |
 | [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md) | Design | Trusted `.szsnap` v2 load mode, serialized symbol hashes/lookups, and <= 200 ms 1M-rule cold-load path. |
 | [19-public-api-completeness-design.md](./19-public-api-completeness-design.md) | Design | Completed public API surface for zstd snapshots, policy text import/export, schema deletion, and permission enumeration. |
+| [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md) | Design | Lock-free read runtime, single-writer actor, batch write path, and tenant sharding. |
 | [60-crates-features-design.md](./60-crates-features-design.md) | Design | Crate layout, feature flags, dependency policy, current crate-version survey. |
 | [70-security-design.md](./70-security-design.md) | Design | Threat model, validation limits, panic policy, unsafe policy, logging/data exposure. |
 | [71-performance-budgets-design.md](./71-performance-budgets-design.md) | Design | Performance targets, benchmark matrix, profiling rules, CI gates. |
@@ -69,7 +70,7 @@ Read the v2 specs in numeric order. The order is also the implementation depende
                                                        v
                                             +----------------------+
                                             | 15 Public API        |
-                                            | facade/examples      |
+                                            | engine/examples      |
                                             +----------+-----------+
                                                        |
                                                        v
@@ -94,6 +95,12 @@ Read the v2 specs in numeric order. The order is also the implementation depende
                                             +----------------------+
                                             | 19 Public API        |
                                             | Completeness         |
+                                            +----------+-----------+
+                                                       |
+                                                       v
+                                            +----------------------+
+                                            | 20 Concurrent        |
+                                            | Engine Runtime       |
                                             +----------+-----------+
                                                        |
                 +------------------------------+-------+------------------------------+

--- a/specs/index.md
+++ b/specs/index.md
@@ -24,6 +24,7 @@ Read the v2 specs in numeric order. The order is also the implementation depende
 | [16-compact-relationship-store-design.md](./16-compact-relationship-store-design.md) | Design | Compact row storage, identifier interning, `Vec<RowId>` postings, snapshot ownership cleanup, memory targets. |
 | [17-compact-snapshot-format-design.md](./17-compact-snapshot-format-design.md) | Design | Versioned compact snapshot artifact for fast load, bounded load-time RSS, and practical disk size. |
 | [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md) | Design | Trusted `.szsnap` v2 load mode, serialized symbol hashes/lookups, and <= 200 ms 1M-rule cold-load path. |
+| [19-public-api-completeness-design.md](./19-public-api-completeness-design.md) | Design | Completed public API surface for zstd snapshots, policy text import/export, schema deletion, and permission enumeration. |
 | [60-crates-features-design.md](./60-crates-features-design.md) | Design | Crate layout, feature flags, dependency policy, current crate-version survey. |
 | [70-security-design.md](./70-security-design.md) | Design | Threat model, validation limits, panic policy, unsafe policy, logging/data exposure. |
 | [71-performance-budgets-design.md](./71-performance-budgets-design.md) | Design | Performance targets, benchmark matrix, profiling rules, CI gates. |
@@ -87,6 +88,12 @@ Read the v2 specs in numeric order. The order is also the implementation depende
                                             +----------------------+
                                             | 18 Trusted Fast Load |
                                             | <=200ms cold start   |
+                                            +----------+-----------+
+                                                       |
+                                                       v
+                                            +----------------------+
+                                            | 19 Public API        |
+                                            | Completeness         |
                                             +----------+-----------+
                                                        |
                 +------------------------------+-------+------------------------------+

--- a/specs/index.md
+++ b/specs/index.md
@@ -1,7 +1,7 @@
 # Specs Index
 
 Status: draft v1
-Last updated: 2026-05-23
+Last updated: 2026-05-24
 
 This directory now has two generations of design material:
 
@@ -26,6 +26,7 @@ Read the v2 specs in numeric order. The order is also the implementation depende
 | [18-trusted-fast-snapshot-load-design.md](./18-trusted-fast-snapshot-load-design.md) | Design | Trusted `.szsnap` v2 load mode, serialized symbol hashes/lookups, and <= 200 ms 1M-rule cold-load path. |
 | [19-public-api-completeness-design.md](./19-public-api-completeness-design.md) | Design | Completed public API surface for zstd snapshots, policy text import/export, schema deletion, and permission enumeration. |
 | [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md) | Design | Lock-free read runtime, single-writer actor, batch write path, and tenant sharding. |
+| [21-performance-optimization-design.md](./21-performance-optimization-design.md) | Design | Dependency-ordered performance optimization plan for write amplification, evaluator latency, lookup allocation, snapshot load/save, and index profiles. |
 | [60-crates-features-design.md](./60-crates-features-design.md) | Design | Crate layout, feature flags, dependency policy, current crate-version survey. |
 | [70-security-design.md](./70-security-design.md) | Design | Threat model, validation limits, panic policy, unsafe policy, logging/data exposure. |
 | [71-performance-budgets-design.md](./71-performance-budgets-design.md) | Design | Performance targets, benchmark matrix, profiling rules, CI gates. |
@@ -101,6 +102,12 @@ Read the v2 specs in numeric order. The order is also the implementation depende
                                             +----------------------+
                                             | 20 Concurrent        |
                                             | Engine Runtime       |
+                                            +----------+-----------+
+                                                       |
+                                                       v
+                                            +----------------------+
+                                            | 21 Performance       |
+                                            | Optimization         |
                                             +----------+-----------+
                                                        |
                 +------------------------------+-------+------------------------------+

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,29 +1,44 @@
 //! Public request/response engine API.
 
 use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    fmt,
     num::NonZeroUsize,
     path::Path,
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    str::FromStr,
+    sync::{
+        Arc, Mutex,
+        mpsc::{self, SyncSender},
+    },
+    thread::{self, JoinHandle},
 };
 
+use arc_swap::{ArcSwap, ArcSwapOption};
 use thiserror::Error;
 
 use crate::{
-    ZanzibarService,
-    domain::DomainError,
+    WriterState,
+    domain::{DomainError, ObjectType, RelationName},
     error::ZanzibarError,
-    eval::{EvaluationError, EvaluationLimits},
+    eval::{self, EvaluationError, EvaluationLimits},
     model::{
-        CheckRequest, CheckResponse, ExpandRequest, ExpandResponse, LookupObjectPermissions,
-        LookupObjectPermissionsRequest, LookupPermissions, LookupPermissionsRequest,
-        LookupResources, LookupResourcesRequest, LookupSubjects, LookupSubjectsRequest,
+        CheckRequest, CheckResponse, ExpandRequest, ExpandResponse, ExpandedUserset,
+        LookupObjectPermissions, LookupObjectPermissionsRequest, LookupPermissions,
+        LookupPermissionsRequest, LookupResources, LookupResourcesRequest, LookupSubjects,
+        LookupSubjectsRequest, NamespaceConfig, Object, PermissionSubjects, Relation,
+        RelationTuple, User,
     },
-    policy::{PolicyIoError, PolicyText},
+    policy::{self, PolicyIoError, PolicyText},
     relationship::{Precondition, RelationshipMutation, StoreError},
-    revision::{ConsistencyError, ConsistencyToken, default_retained_snapshots},
+    revision::{Consistency, ConsistencyError, ConsistencyToken, default_retained_snapshots},
+    runtime::{EngineState, SharedEngineState},
     schema::{SchemaError, SchemaSource},
     snapshot::{SnapshotIoError, SnapshotLoadOptions, SnapshotSaveOptions},
 };
+
+const DEFAULT_WRITER_QUEUE_CAPACITY: usize = 1024;
+const MAX_TENANT_ID_BYTES: usize = 128;
 
 macro_rules! enter_api_span {
     ($operation:literal) => {
@@ -34,104 +49,13 @@ macro_rules! enter_api_span {
 
 /// Public local Zanzibar engine.
 ///
-/// The engine owns the in-memory schema, relationship indexes, retained revision snapshots, and a
-/// writer gate. All public reads acquire one coherent published snapshot, while writes publish a
-/// new snapshot atomically.
-///
-/// ```
-/// use simple_zanzibar::domain::Relationship;
-/// use simple_zanzibar::model::{
-///     CheckRequest, ExpandRequest, LookupResourcesRequest, LookupSubjectsRequest, Object,
-///     Relation, User,
-/// };
-/// use simple_zanzibar::relationship::{
-///     Precondition, RelationshipFilter, RelationshipMutation, SubjectFilter,
-/// };
-/// use simple_zanzibar::revision::Consistency;
-/// use simple_zanzibar::schema::SchemaSource;
-/// use simple_zanzibar::ZanzibarEngine;
-///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let engine = ZanzibarEngine::builder().build();
-/// engine.apply_schema(SchemaSource {
-///     name: Some("docs"),
-///     text: r"
-///     namespace doc {
-///         relation viewer {}
-///     }
-///     ",
-/// })?;
-///
-/// let relationship: Relationship = "doc:readme#viewer@user:alice".parse()?;
-/// let subject = SubjectFilter::exact("user".try_into()?, "alice".try_into()?, None);
-/// let precondition = Precondition::MustNotMatch(RelationshipFilter::for_exact_subject(
-///     relationship.resource(),
-///     relationship.relation().clone(),
-///     subject,
-/// ));
-/// let token = engine.write_relationships_with_preconditions(
-///     [RelationshipMutation::Touch(relationship)],
-///     [precondition],
-/// )?;
-///
-/// let doc = Object {
-///     namespace: "doc".to_string(),
-///     id: "readme".to_string(),
-/// };
-/// let viewer = Relation("viewer".to_string());
-/// let alice = User::UserId("alice".to_string());
-///
-/// assert!(
-///     engine
-///         .check(CheckRequest::new(
-///             doc.clone(),
-///             viewer.clone(),
-///             alice.clone(),
-///             Consistency::Latest,
-///         ))?
-///         .allowed
-/// );
-/// assert!(
-///     engine
-///         .check(CheckRequest::new(
-///             doc.clone(),
-///             viewer.clone(),
-///             alice.clone(),
-///             Consistency::Exact(token),
-///         ))?
-///         .allowed
-/// );
-/// engine.expand(ExpandRequest::new(
-///     doc.clone(),
-///     viewer.clone(),
-///     Consistency::Latest,
-/// ))?;
-/// assert_eq!(
-///     engine
-///         .lookup_resources(LookupResourcesRequest {
-///             subject: alice.clone(),
-///             permission: viewer.clone(),
-///             resource_type: "doc".to_string(),
-///         })?
-///         .resources,
-///     vec![doc.clone()],
-/// );
-/// assert_eq!(
-///     engine
-///         .lookup_subjects(LookupSubjectsRequest {
-///             resource: doc,
-///             permission: viewer,
-///             subject_type: "user".to_string(),
-///         })?
-///         .subjects,
-///     vec![alice],
-/// );
-/// # Ok(())
-/// # }
-/// ```
+/// Reads clone immutable published snapshots through an atomic pointer and do not acquire a
+/// service-level lock. Writes are submitted to one bounded writer actor that owns the mutable
+/// schema, relationship store, and revision history for this engine instance.
 #[derive(Debug)]
 pub struct ZanzibarEngine {
-    service: RwLock<ZanzibarService>,
+    state: SharedEngineState,
+    writer: WriterActor,
 }
 
 impl ZanzibarEngine {
@@ -149,14 +73,78 @@ impl ZanzibarEngine {
     /// fails.
     pub fn check(&self, request: CheckRequest) -> Result<CheckResponse, EngineError> {
         enter_api_span!("check");
-        let service = self.read_service("check")?;
-        let allowed = service.check_with_consistency(
+        let (snapshot, limits) = self.snapshot_for_consistency(request.consistency)?;
+        let object_type = ObjectType::try_from(request.object.namespace.as_str())?;
+        let relation_name = RelationName::try_from(request.relation.0.as_str())?;
+        snapshot
+            .schema()
+            .resolver()
+            .relation(&object_type, &relation_name)?;
+        let allowed = eval::check_with_snapshot(
+            &snapshot,
             &request.object,
             &request.relation,
             &request.user,
-            request.consistency,
-        )?;
+            limits,
+        )?
+        .is_allowed();
         Ok(CheckResponse { allowed })
+    }
+
+    /// Checks a relation or permission using latest consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn check_relation(
+        &self,
+        object: &Object,
+        relation: &Relation,
+        user: &User,
+    ) -> Result<bool, EngineError> {
+        self.check_relation_with_consistency(object, relation, user, Consistency::Latest)
+    }
+
+    /// Checks a relation or permission at the requested consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn check_relation_with_consistency(
+        &self,
+        object: &Object,
+        relation: &Relation,
+        user: &User,
+        consistency: Consistency,
+    ) -> Result<bool, EngineError> {
+        Ok(self
+            .check(CheckRequest::new(
+                object.clone(),
+                relation.clone(),
+                user.clone(),
+                consistency,
+            ))?
+            .allowed)
+    }
+
+    /// Checks a relation or permission at the requested consistency.
+    ///
+    /// This convenience method is equivalent to [`Self::check_relation_with_consistency`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn check_with_consistency(
+        &self,
+        object: &Object,
+        relation: &Relation,
+        user: &User,
+        consistency: Consistency,
+    ) -> Result<bool, EngineError> {
+        self.check_relation_with_consistency(object, relation, user, consistency)
     }
 
     /// Expands the effective userset for an object relation or permission.
@@ -167,13 +155,36 @@ impl ZanzibarEngine {
     /// fails.
     pub fn expand(&self, request: ExpandRequest) -> Result<ExpandResponse, EngineError> {
         enter_api_span!("expand");
-        let service = self.read_service("expand")?;
-        let expanded = service.expand_with_consistency(
-            &request.object,
-            &request.relation,
-            request.consistency,
-        )?;
+        let (snapshot, limits) = self.snapshot_for_consistency(request.consistency)?;
+        let object_type = ObjectType::try_from(request.object.namespace.as_str())?;
+        let relation_name = RelationName::try_from(request.relation.0.as_str())?;
+        snapshot
+            .schema()
+            .resolver()
+            .relation(&object_type, &relation_name)?;
+        let expanded =
+            eval::expand_with_snapshot(&snapshot, &request.object, &request.relation, limits)?;
         Ok(ExpandResponse { expanded })
+    }
+
+    /// Expands a relation or permission using latest consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn expand_relation(
+        &self,
+        object: &Object,
+        relation: &Relation,
+    ) -> Result<ExpandedUserset, EngineError> {
+        Ok(self
+            .expand(ExpandRequest::new(
+                object.clone(),
+                relation.clone(),
+                Consistency::Latest,
+            ))?
+            .expanded)
     }
 
     /// Looks up resources of a type that a subject can access at latest consistency.
@@ -181,18 +192,30 @@ impl ZanzibarEngine {
     /// # Errors
     ///
     /// Returns [`EngineError`] when request validation, store access, or evaluation fails.
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "public API follows the request/response ownership contract in \
-                  specs/15-public-api-design.md"
-    )]
     pub fn lookup_resources(
         &self,
-        request: LookupResourcesRequest,
+        request: impl Borrow<LookupResourcesRequest>,
+    ) -> Result<LookupResources, EngineError> {
+        self.lookup_resources_with_consistency(request, Consistency::Latest)
+    }
+
+    /// Looks up resources of a type at the requested consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn lookup_resources_with_consistency(
+        &self,
+        request: impl Borrow<LookupResourcesRequest>,
+        consistency: Consistency,
     ) -> Result<LookupResources, EngineError> {
         enter_api_span!("lookup_resources");
-        let service = self.read_service("lookup_resources")?;
-        Ok(service.lookup_resources(&request)?)
+        let (snapshot, limits) = self.snapshot_for_consistency(consistency)?;
+        let request = request.borrow();
+        Ok(eval::lookup_resources_with_snapshot(
+            &snapshot, request, limits,
+        )?)
     }
 
     /// Looks up subjects of a type that can access a resource at latest consistency.
@@ -200,18 +223,30 @@ impl ZanzibarEngine {
     /// # Errors
     ///
     /// Returns [`EngineError`] when request validation, store access, or evaluation fails.
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "public API follows the request/response ownership contract in \
-                  specs/15-public-api-design.md"
-    )]
     pub fn lookup_subjects(
         &self,
-        request: LookupSubjectsRequest,
+        request: impl Borrow<LookupSubjectsRequest>,
+    ) -> Result<LookupSubjects, EngineError> {
+        self.lookup_subjects_with_consistency(request, Consistency::Latest)
+    }
+
+    /// Looks up subjects of a type at the requested consistency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, consistency, store access, or evaluation
+    /// fails.
+    pub fn lookup_subjects_with_consistency(
+        &self,
+        request: impl Borrow<LookupSubjectsRequest>,
+        consistency: Consistency,
     ) -> Result<LookupSubjects, EngineError> {
         enter_api_span!("lookup_subjects");
-        let service = self.read_service("lookup_subjects")?;
-        Ok(service.lookup_subjects(&request)?)
+        let (snapshot, limits) = self.snapshot_for_consistency(consistency)?;
+        let request = request.borrow();
+        Ok(eval::lookup_subjects_with_snapshot(
+            &snapshot, request, limits,
+        )?)
     }
 
     /// Applies relationship mutations and publishes a new revision.
@@ -228,6 +263,74 @@ impl ZanzibarEngine {
         self.write_relationships_with_preconditions(mutations, [])
     }
 
+    /// Applies relationship mutations with optional preconditions.
+    ///
+    /// This is an alias for [`Self::write_relationships_with_preconditions`] kept as the explicit
+    /// batch mutation verb in the public API.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when no schema is loaded, validation fails, preconditions fail, or
+    /// mutation semantics are invalid.
+    pub fn apply_relationship_mutations(
+        &self,
+        mutations: impl IntoIterator<Item = RelationshipMutation>,
+        preconditions: impl IntoIterator<Item = Precondition>,
+    ) -> Result<ConsistencyToken, EngineError> {
+        self.write_relationships_with_preconditions(mutations, preconditions)
+    }
+
+    /// Writes one legacy tuple as an idempotent relationship touch.
+    ///
+    /// Prefer [`Self::write_relationships`] for high-throughput callers because it batches many
+    /// mutations into one writer-actor turn.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the tuple is invalid, no schema is loaded, or validation fails.
+    pub fn write_tuple(&self, tuple: impl Borrow<RelationTuple>) -> Result<(), EngineError> {
+        self.write_tuple_with_token(tuple.borrow()).map(drop)
+    }
+
+    /// Writes one legacy tuple as an idempotent relationship touch and returns the published token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the tuple is invalid, no schema is loaded, or validation fails.
+    pub fn write_tuple_with_token(
+        &self,
+        tuple: &RelationTuple,
+    ) -> Result<ConsistencyToken, EngineError> {
+        let relationship = crate::domain::Relationship::try_from(tuple)?;
+        self.write_relationships([RelationshipMutation::Touch(relationship)])
+    }
+
+    /// Deletes one legacy tuple.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the tuple is invalid, no schema is loaded, validation fails, or
+    /// the tuple is absent.
+    pub fn delete_tuple(&self, tuple: &RelationTuple) -> Result<(), EngineError> {
+        let relationship = crate::domain::Relationship::try_from(tuple)?;
+        self.write_relationships([RelationshipMutation::Delete(relationship)])
+            .map(drop)
+    }
+
+    /// Deletes one legacy tuple and returns the published token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the tuple is invalid, no schema is loaded, validation fails, or
+    /// the tuple is absent.
+    pub fn delete_tuple_with_token(
+        &self,
+        tuple: &RelationTuple,
+    ) -> Result<ConsistencyToken, EngineError> {
+        let relationship = crate::domain::Relationship::try_from(tuple)?;
+        self.write_relationships([RelationshipMutation::Delete(relationship)])
+    }
+
     /// Creates one relationship, failing if it already exists.
     ///
     /// # Errors
@@ -236,8 +339,7 @@ impl ZanzibarEngine {
     /// validation fails, or the relationship already exists.
     pub fn create_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("create_relationship");
-        let mutation = RelationshipMutation::create(relationship)?;
-        self.write_relationships([mutation])
+        self.write_relationships([RelationshipMutation::create(relationship)?])
     }
 
     /// Grants or refreshes one relationship idempotently.
@@ -248,8 +350,7 @@ impl ZanzibarEngine {
     /// validation fails.
     pub fn touch_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("touch_relationship");
-        let mutation = RelationshipMutation::touch(relationship)?;
-        self.write_relationships([mutation])
+        self.write_relationships([RelationshipMutation::touch(relationship)?])
     }
 
     /// Deletes one relationship, failing if it does not exist.
@@ -260,8 +361,7 @@ impl ZanzibarEngine {
     /// validation fails, or the relationship does not exist.
     pub fn delete_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("delete_relationship");
-        let mutation = RelationshipMutation::delete(relationship)?;
-        self.write_relationships([mutation])
+        self.write_relationships([RelationshipMutation::delete(relationship)?])
     }
 
     /// Applies relationship mutations with preconditions and publishes a new revision.
@@ -276,8 +376,13 @@ impl ZanzibarEngine {
         preconditions: impl IntoIterator<Item = Precondition>,
     ) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("write_relationships_with_preconditions");
-        let mut service = self.write_service("write_relationships")?;
-        Ok(service.apply_relationship_mutations(mutations, preconditions)?)
+        self.submit_write("write_relationships", |response| {
+            WriterCommand::WriteRelationships {
+                mutations: mutations.into_iter().collect(),
+                preconditions: preconditions.into_iter().collect(),
+                response,
+            }
+        })
     }
 
     /// Applies a schema document and publishes a new revision.
@@ -287,8 +392,70 @@ impl ZanzibarEngine {
     /// Returns [`EngineError`] when the schema cannot be parsed or validated.
     pub fn apply_schema(&self, source: SchemaSource<'_>) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("apply_schema");
-        let mut service = self.write_service("apply_schema")?;
-        Ok(service.add_dsl_with_token(source.text)?)
+        self.submit_write("apply_schema", |response| WriterCommand::ApplySchema {
+            text: source.text.to_string(),
+            response,
+        })
+    }
+
+    /// Applies a legacy DSL schema document and publishes a new revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the DSL cannot be parsed or validated.
+    pub fn add_dsl(&self, dsl: &str) -> Result<(), EngineError> {
+        self.add_dsl_with_token(dsl).map(drop)
+    }
+
+    /// Applies a legacy DSL schema document and returns the published token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the DSL cannot be parsed or validated.
+    pub fn add_dsl_with_token(&self, dsl: &str) -> Result<ConsistencyToken, EngineError> {
+        self.apply_schema(SchemaSource {
+            name: Some("dsl"),
+            text: dsl,
+        })
+    }
+
+    /// Applies one structured namespace config and publishes a new revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the namespace config cannot be validated.
+    pub fn apply_namespace_config(
+        &self,
+        config: NamespaceConfig,
+    ) -> Result<ConsistencyToken, EngineError> {
+        self.apply_namespace_configs([config])
+    }
+
+    /// Applies one structured namespace config and returns the published token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the namespace config cannot be validated.
+    pub fn add_config_with_token(
+        &self,
+        config: NamespaceConfig,
+    ) -> Result<ConsistencyToken, EngineError> {
+        self.apply_namespace_config(config)
+    }
+
+    /// Applies structured namespace configs and publishes a single new revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when any namespace config cannot be validated.
+    pub fn apply_namespace_configs(
+        &self,
+        configs: impl IntoIterator<Item = NamespaceConfig>,
+    ) -> Result<ConsistencyToken, EngineError> {
+        let configs = configs.into_iter().collect();
+        self.submit_write("apply_namespace_configs", |response| {
+            WriterCommand::ApplyNamespaceConfigs { configs, response }
+        })
     }
 
     /// Replaces the complete schema document and publishes a new revision.
@@ -302,8 +469,10 @@ impl ZanzibarEngine {
         source: SchemaSource<'_>,
     ) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("replace_schema");
-        let mut service = self.write_service("replace_schema")?;
-        Ok(service.replace_dsl_with_token(source.text)?)
+        self.submit_write("replace_schema", |response| WriterCommand::ReplaceSchema {
+            text: source.text.to_string(),
+            response,
+        })
     }
 
     /// Deletes one namespace definition.
@@ -314,8 +483,12 @@ impl ZanzibarEngine {
     /// reference it.
     pub fn delete_namespace(&self, namespace: &str) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("delete_namespace");
-        let mut service = self.write_service("delete_namespace")?;
-        Ok(service.delete_namespace(namespace)?)
+        self.submit_write("delete_namespace", |response| {
+            WriterCommand::DeleteNamespace {
+                namespace: namespace.to_string(),
+                response,
+            }
+        })
     }
 
     /// Deletes one relation definition.
@@ -330,8 +503,13 @@ impl ZanzibarEngine {
         relation: &str,
     ) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("delete_relation");
-        let mut service = self.write_service("delete_relation")?;
-        Ok(service.delete_relation(namespace, relation)?)
+        self.submit_write("delete_relation", |response| {
+            WriterCommand::DeleteRelation {
+                namespace: namespace.to_string(),
+                relation: relation.to_string(),
+                response,
+            }
+        })
     }
 
     /// Builds a new engine from policy text.
@@ -341,9 +519,9 @@ impl ZanzibarEngine {
     /// Returns [`EngineError`] when policy text cannot be parsed or validated.
     pub fn from_policy_text(policy: &PolicyText) -> Result<Self, EngineError> {
         enter_api_span!("from_policy_text");
-        Ok(Self {
-            service: RwLock::new(ZanzibarService::from_policy_text(policy)?),
-        })
+        let engine = Self::builder().build();
+        engine.apply_policy_text(policy)?;
+        Ok(engine)
     }
 
     /// Replaces this engine's state with policy text.
@@ -353,8 +531,23 @@ impl ZanzibarEngine {
     /// Returns [`EngineError`] when policy text cannot be parsed or validated.
     pub fn apply_policy_text(&self, policy: &PolicyText) -> Result<ConsistencyToken, EngineError> {
         enter_api_span!("apply_policy_text");
-        let mut service = self.write_service("apply_policy_text")?;
-        Ok(service.apply_policy_text(policy)?)
+        let policy = policy.clone();
+        self.submit_write("apply_policy_text", |response| {
+            WriterCommand::ApplyPolicyText { policy, response }
+        })
+    }
+
+    /// Saves a snapshot built from policy text without keeping an engine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyIoError`] when policy parsing or snapshot writing fails.
+    pub fn save_snapshot_from_policy_text(
+        path: impl AsRef<Path>,
+        policy: &PolicyText,
+        options: SnapshotSaveOptions,
+    ) -> Result<(), PolicyIoError> {
+        policy::save_snapshot_from_policy_text(path.as_ref(), policy, options)
     }
 
     /// Exports the latest state as deterministic policy text.
@@ -364,25 +557,28 @@ impl ZanzibarEngine {
     /// Returns [`EngineError`] when no schema has been loaded.
     pub fn export_policy_text(&self) -> Result<PolicyText, EngineError> {
         enter_api_span!("export_policy_text");
-        let service = self.read_service("export_policy_text")?;
-        Ok(service.export_policy_text()?)
+        let snapshot = self.latest_snapshot()?;
+        Ok(policy::export_policy_text(
+            snapshot.configs(),
+            snapshot.relationships().rows(),
+        ))
     }
 
     /// Exports deterministic policy files under `directory`.
     ///
     /// # Errors
     ///
-    /// Returns [`PolicyIoError`] when no schema has been loaded, locking fails, or file output
-    /// fails.
+    /// Returns [`PolicyIoError`] when no schema has been loaded or file output fails.
     pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError> {
         enter_api_span!("export_policy_files");
-        let service = self
-            .service
-            .read()
-            .map_err(|_| PolicyIoError::LockPoisoned {
-                operation: "export_policy_files",
+        let snapshot = self
+            .latest_snapshot()
+            .map_err(|_| PolicyIoError::Zanzibar {
+                source: ZanzibarError::SchemaRequired,
             })?;
-        service.export_policy_files(directory)
+        let policy =
+            policy::export_policy_text(snapshot.configs(), snapshot.relationships().rows());
+        policy::write_policy_files(directory.as_ref(), &policy)
     }
 
     /// Looks up every relation or permission a subject has on one resource.
@@ -390,18 +586,33 @@ impl ZanzibarEngine {
     /// # Errors
     ///
     /// Returns [`EngineError`] when request validation or evaluation fails.
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "public API follows the request/response ownership contract in \
-                  specs/19-public-api-completeness-design.md"
-    )]
     pub fn lookup_permissions(
         &self,
-        request: LookupPermissionsRequest,
+        request: impl Borrow<LookupPermissionsRequest>,
     ) -> Result<LookupPermissions, EngineError> {
         enter_api_span!("lookup_permissions");
-        let service = self.read_service("lookup_permissions")?;
-        Ok(service.lookup_permissions(&request)?)
+        let request = request.borrow();
+        let (snapshot, limits) = self.snapshot_for_consistency(request.consistency.clone())?;
+        let object_type = ObjectType::try_from(request.resource.namespace.as_str())?;
+        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
+        let mut permissions = Vec::new();
+        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
+        relations.sort_by(|left, right| left.name().cmp(right.name()));
+        for relation_definition in relations {
+            let relation = Relation(relation_definition.name().as_str().to_string());
+            if eval::check_with_snapshot(
+                &snapshot,
+                &request.resource,
+                &relation,
+                &request.subject,
+                limits,
+            )?
+            .is_allowed()
+            {
+                permissions.push(relation);
+            }
+        }
+        Ok(LookupPermissions { permissions })
     }
 
     /// Looks up subjects grouped by every relation or permission they have on one resource.
@@ -409,25 +620,50 @@ impl ZanzibarEngine {
     /// # Errors
     ///
     /// Returns [`EngineError`] when request validation, store access, or evaluation fails.
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "public API follows the request/response ownership contract in \
-                  specs/19-public-api-completeness-design.md"
-    )]
     pub fn lookup_object_permissions(
         &self,
-        request: LookupObjectPermissionsRequest,
+        request: impl Borrow<LookupObjectPermissionsRequest>,
     ) -> Result<LookupObjectPermissions, EngineError> {
         enter_api_span!("lookup_object_permissions");
-        let service = self.read_service("lookup_object_permissions")?;
-        Ok(service.lookup_object_permissions(&request)?)
+        let request = request.borrow();
+        let (snapshot, limits) = self.snapshot_for_consistency(request.consistency.clone())?;
+        let object_type = ObjectType::try_from(request.resource.namespace.as_str())?;
+        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
+        let subject_type = crate::domain::SubjectType::try_from(request.subject_type.as_str())?;
+        if subject_type.as_str() != "user" {
+            let subject_object_type = ObjectType::try_from(subject_type.as_str())?;
+            snapshot
+                .schema()
+                .resolver()
+                .namespace(&subject_object_type)?;
+        }
+
+        let mut permissions = Vec::new();
+        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
+        relations.sort_by(|left, right| left.name().cmp(right.name()));
+        for relation_definition in relations {
+            let permission = Relation(relation_definition.name().as_str().to_string());
+            let subjects = eval::lookup_subjects_with_snapshot(
+                &snapshot,
+                &LookupSubjectsRequest {
+                    resource: request.resource.clone(),
+                    permission: permission.clone(),
+                    subject_type: request.subject_type.clone(),
+                },
+                limits,
+            )?
+            .subjects;
+            if !subjects.is_empty() {
+                permissions.push(PermissionSubjects {
+                    permission,
+                    subjects,
+                });
+            }
+        }
+        Ok(LookupObjectPermissions { permissions })
     }
 
     /// Saves the latest published snapshot to a versioned `.szsnap` artifact.
-    ///
-    /// This writes a deterministic deployment artifact for trusted build or release pipelines.
-    /// The artifact does not preserve the engine's datastore id; consistency tokens issued before
-    /// saving remain scoped to the writer engine and are not accepted by later loaded engines.
     ///
     /// # Errors
     ///
@@ -439,18 +675,18 @@ impl ZanzibarEngine {
         options: SnapshotSaveOptions,
     ) -> Result<(), SnapshotIoError> {
         enter_api_span!("save_snapshot");
-        let service = self.service.read().map_err(|_| SnapshotIoError::Format {
-            reason: "engine lock poisoned during snapshot save",
+        let snapshot = self.latest_snapshot().map_err(|error| match error {
+            EngineError::SchemaRequired => SnapshotIoError::Format {
+                reason: "schema snapshot is required before saving",
+            },
+            _ => SnapshotIoError::Format {
+                reason: "engine state unavailable during snapshot save",
+            },
         })?;
-        service.save_snapshot(path, options)
+        crate::snapshot::save_snapshot_file(path.as_ref(), &snapshot, options)
     }
 
     /// Loads a versioned `.szsnap` artifact into a new engine.
-    ///
-    /// Snapshot files are treated as untrusted input: the loader validates the envelope, section
-    /// directory, checksum, schema, relationships, and indexes before publishing the snapshot. The
-    /// loaded engine receives a fresh datastore id, so exact consistency tokens from the writer
-    /// process are rejected by design.
     ///
     /// # Errors
     ///
@@ -460,27 +696,44 @@ impl ZanzibarEngine {
         options: SnapshotLoadOptions,
     ) -> Result<Self, SnapshotIoError> {
         enter_api_span!("load_snapshot");
+        let state = Arc::new(ArcSwapOption::empty());
+        let writer_state =
+            WriterState::load_snapshot_with_publisher(path, options, Arc::clone(&state))?;
         Ok(Self {
-            service: RwLock::new(ZanzibarService::load_snapshot(path, options)?),
+            state,
+            writer: WriterActor::start(writer_state, default_writer_queue_capacity()),
         })
     }
 
-    fn read_service(
+    fn submit_write(
         &self,
         operation: &'static str,
-    ) -> Result<RwLockReadGuard<'_, ZanzibarService>, EngineError> {
-        self.service
-            .read()
-            .map_err(|_| EngineError::LockPoisoned { operation })
+        build_command: impl FnOnce(WriteResponseSender) -> WriterCommand,
+    ) -> Result<ConsistencyToken, EngineError> {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        self.writer.send(build_command(sender), operation)?;
+        receiver
+            .recv()
+            .map_err(|_| EngineError::WriterUnavailable { operation })?
+            .map_err(EngineError::from)
     }
 
-    fn write_service(
+    fn current_state(&self) -> Result<Arc<EngineState>, EngineError> {
+        self.state.load_full().ok_or(EngineError::SchemaRequired)
+    }
+
+    fn latest_snapshot(&self) -> Result<Arc<crate::revision::PublishedSnapshot>, EngineError> {
+        Ok(self.current_state()?.latest_snapshot())
+    }
+
+    fn snapshot_for_consistency(
         &self,
-        operation: &'static str,
-    ) -> Result<RwLockWriteGuard<'_, ZanzibarService>, EngineError> {
-        self.service
-            .write()
-            .map_err(|_| EngineError::LockPoisoned { operation })
+        consistency: Consistency,
+    ) -> Result<(Arc<crate::revision::PublishedSnapshot>, EvaluationLimits), EngineError> {
+        let state = self.current_state()?;
+        let limits = state.evaluation_limits();
+        let snapshot = state.snapshot_for_consistency(consistency)?;
+        Ok((snapshot, limits))
     }
 }
 
@@ -495,6 +748,7 @@ impl Default for ZanzibarEngine {
 pub struct ZanzibarEngineBuilder {
     retained_snapshots: NonZeroUsize,
     evaluation_limits: EvaluationLimits,
+    writer_queue_capacity: NonZeroUsize,
 }
 
 impl ZanzibarEngineBuilder {
@@ -504,6 +758,7 @@ impl ZanzibarEngineBuilder {
         Self {
             retained_snapshots: default_retained_snapshots(),
             evaluation_limits: EvaluationLimits::default(),
+            writer_queue_capacity: default_writer_queue_capacity(),
         }
     }
 
@@ -521,13 +776,25 @@ impl ZanzibarEngineBuilder {
         self
     }
 
+    /// Sets the bounded writer actor queue capacity.
+    #[must_use]
+    pub fn writer_queue_capacity(mut self, writer_queue_capacity: NonZeroUsize) -> Self {
+        self.writer_queue_capacity = writer_queue_capacity;
+        self
+    }
+
     /// Builds the engine.
     #[must_use]
     pub fn build(self) -> ZanzibarEngine {
-        let service = ZanzibarService::with_snapshot_retention(self.retained_snapshots)
-            .with_evaluation_limits(self.evaluation_limits);
+        let state = Arc::new(ArcSwapOption::empty());
+        let writer_state = WriterState::with_snapshot_retention_and_publisher(
+            self.retained_snapshots,
+            Arc::clone(&state),
+        )
+        .with_evaluation_limits(self.evaluation_limits);
         ZanzibarEngine {
-            service: RwLock::new(service),
+            state,
+            writer: WriterActor::start(writer_state, self.writer_queue_capacity),
         }
     }
 }
@@ -535,6 +802,137 @@ impl ZanzibarEngineBuilder {
 impl Default for ZanzibarEngineBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Validated tenant identifier used by [`ZanzibarTenantShards`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TenantId(String);
+
+impl TenantId {
+    /// Creates a tenant id after validating length and charset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TenantIdError`] when `value` is empty, too long, or contains unsupported bytes.
+    pub fn new(value: impl Into<String>) -> Result<Self, TenantIdError> {
+        let value = value.into();
+        validate_tenant_id(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the tenant id as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = TenantIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for TenantId {
+    type Error = TenantIdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Error returned by [`TenantId`] validation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TenantIdError {
+    /// Tenant id was empty.
+    #[error("tenant id must not be empty")]
+    Empty,
+    /// Tenant id exceeded the maximum byte length.
+    #[error("tenant id exceeds maximum byte length {max_bytes}")]
+    TooLong {
+        /// Maximum accepted tenant id length in bytes.
+        max_bytes: usize,
+    },
+    /// Tenant id contained an unsupported byte.
+    #[error("tenant id contains invalid byte at offset {offset}")]
+    InvalidByte {
+        /// Byte offset of the invalid value.
+        offset: usize,
+    },
+}
+
+/// Tenant-sharded owner of independent [`ZanzibarEngine`] instances.
+#[derive(Debug)]
+pub struct ZanzibarTenantShards {
+    shards: Arc<ArcSwap<ShardMap>>,
+    create_gate: Mutex<()>,
+    builder: ZanzibarEngineBuilder,
+}
+
+impl ZanzibarTenantShards {
+    /// Creates an empty tenant shard set using `builder` for new tenants.
+    #[must_use]
+    pub fn new(builder: ZanzibarEngineBuilder) -> Self {
+        Self {
+            shards: Arc::new(ArcSwap::from_pointee(ShardMap::default())),
+            create_gate: Mutex::new(()),
+            builder,
+        }
+    }
+
+    /// Returns an existing tenant engine without creating it.
+    #[must_use]
+    pub fn get(&self, tenant: &TenantId) -> Option<Arc<ZanzibarEngine>> {
+        self.shards.load_full().engines.get(tenant).cloned()
+    }
+
+    /// Returns an existing tenant engine or creates one under a short creation gate.
+    #[must_use]
+    pub fn get_or_create(&self, tenant: TenantId) -> Arc<ZanzibarEngine> {
+        if let Some(engine) = self.get(&tenant) {
+            return engine;
+        }
+        let _guard = self
+            .create_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(engine) = self.get(&tenant) {
+            return engine;
+        }
+        let mut next = (*self.shards.load_full()).clone();
+        let engine = Arc::new(self.builder.build());
+        next.engines.insert(tenant, Arc::clone(&engine));
+        self.shards.store(Arc::new(next));
+        engine
+    }
+
+    /// Returns sorted tenant ids currently present in this shard set.
+    #[must_use]
+    pub fn tenants(&self) -> Vec<TenantId> {
+        let mut tenants = self
+            .shards
+            .load_full()
+            .engines
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        tenants.sort();
+        tenants
+    }
+}
+
+impl Default for ZanzibarTenantShards {
+    fn default() -> Self {
+        Self::new(ZanzibarEngine::builder())
     }
 }
 
@@ -595,10 +993,10 @@ pub enum EngineError {
     #[error("schema must be loaded before this operation")]
     SchemaRequired,
 
-    /// The engine lock was poisoned by a previous panic.
-    #[error("engine lock poisoned during {operation}")]
-    LockPoisoned {
-        /// Operation that attempted to acquire the poisoned lock.
+    /// The writer actor is unavailable.
+    #[error("engine writer actor unavailable during {operation}")]
+    WriterUnavailable {
+        /// Operation that attempted to use the writer actor.
         operation: &'static str,
     },
 }
@@ -619,6 +1017,29 @@ impl From<ZanzibarError> for EngineError {
             ZanzibarError::Store(error) => Self::Store(error),
             ZanzibarError::Consistency(error) => Self::Consistency(error),
             ZanzibarError::Evaluation(error) => Self::Evaluation(error),
+        }
+    }
+}
+
+impl From<EngineError> for ZanzibarError {
+    fn from(error: EngineError) -> Self {
+        match error {
+            EngineError::NamespaceNotFound { namespace } => Self::NamespaceNotFound(namespace),
+            EngineError::RelationNotFound {
+                namespace,
+                relation,
+            } => Self::RelationNotFound(relation, namespace),
+            EngineError::ParseError { message } => Self::ParseError(message),
+            EngineError::StorageError { message } => Self::StorageError(message),
+            EngineError::SchemaRequired => Self::SchemaRequired,
+            EngineError::Domain(error) => Self::Domain(error),
+            EngineError::Schema(error) => Self::Schema(error),
+            EngineError::Store(error) => Self::Store(error),
+            EngineError::Consistency(error) => Self::Consistency(error),
+            EngineError::Evaluation(error) => Self::Evaluation(error),
+            EngineError::WriterUnavailable { operation } => Self::StorageError(format!(
+                "engine writer actor unavailable during {operation}",
+            )),
         }
     }
 }
@@ -651,4 +1072,164 @@ impl From<EvaluationError> for EngineError {
     fn from(error: EvaluationError) -> Self {
         Self::Evaluation(error)
     }
+}
+
+type WriteResponseSender = SyncSender<Result<ConsistencyToken, ZanzibarError>>;
+
+enum WriterCommand {
+    WriteRelationships {
+        mutations: Vec<RelationshipMutation>,
+        preconditions: Vec<Precondition>,
+        response: WriteResponseSender,
+    },
+    ApplySchema {
+        text: String,
+        response: WriteResponseSender,
+    },
+    ApplyNamespaceConfigs {
+        configs: Vec<NamespaceConfig>,
+        response: WriteResponseSender,
+    },
+    ReplaceSchema {
+        text: String,
+        response: WriteResponseSender,
+    },
+    DeleteNamespace {
+        namespace: String,
+        response: WriteResponseSender,
+    },
+    DeleteRelation {
+        namespace: String,
+        relation: String,
+        response: WriteResponseSender,
+    },
+    ApplyPolicyText {
+        policy: PolicyText,
+        response: WriteResponseSender,
+    },
+    Shutdown,
+}
+
+struct WriterActor {
+    sender: Mutex<Option<SyncSender<WriterCommand>>>,
+    handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl WriterActor {
+    fn start(mut state: WriterState, queue_capacity: NonZeroUsize) -> Self {
+        let (sender, receiver) = mpsc::sync_channel(queue_capacity.get());
+        let handle = thread::spawn(move || {
+            while let Ok(command) = receiver.recv() {
+                match command {
+                    WriterCommand::WriteRelationships {
+                        mutations,
+                        preconditions,
+                        response,
+                    } => {
+                        drop(
+                            response
+                                .send(state.apply_relationship_mutations(mutations, preconditions)),
+                        );
+                    }
+                    WriterCommand::ApplySchema { text, response } => {
+                        drop(response.send(state.add_dsl_with_token(&text)));
+                    }
+                    WriterCommand::ApplyNamespaceConfigs { configs, response } => {
+                        drop(response.send(state.apply_namespace_configs(configs)));
+                    }
+                    WriterCommand::ReplaceSchema { text, response } => {
+                        drop(response.send(state.replace_dsl_with_token(&text)));
+                    }
+                    WriterCommand::DeleteNamespace {
+                        namespace,
+                        response,
+                    } => {
+                        drop(response.send(state.delete_namespace(&namespace)));
+                    }
+                    WriterCommand::DeleteRelation {
+                        namespace,
+                        relation,
+                        response,
+                    } => {
+                        drop(response.send(state.delete_relation(&namespace, &relation)));
+                    }
+                    WriterCommand::ApplyPolicyText { policy, response } => {
+                        drop(response.send(state.apply_policy_text(&policy)));
+                    }
+                    WriterCommand::Shutdown => break,
+                }
+            }
+        });
+        Self {
+            sender: Mutex::new(Some(sender)),
+            handle: Mutex::new(Some(handle)),
+        }
+    }
+
+    fn send(&self, command: WriterCommand, operation: &'static str) -> Result<(), EngineError> {
+        let guard = self
+            .sender
+            .lock()
+            .map_err(|_| EngineError::WriterUnavailable { operation })?;
+        let sender = guard
+            .as_ref()
+            .ok_or(EngineError::WriterUnavailable { operation })?;
+        sender
+            .send(command)
+            .map_err(|_| EngineError::WriterUnavailable { operation })
+    }
+}
+
+impl fmt::Debug for WriterActor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WriterActor")
+            .field("sender", &"<sync sender>")
+            .field("handle", &"<join handle>")
+            .finish()
+    }
+}
+
+impl Drop for WriterActor {
+    fn drop(&mut self) {
+        if let Ok(mut sender) = self.sender.lock()
+            && let Some(sender) = sender.take()
+        {
+            drop(sender.try_send(WriterCommand::Shutdown));
+        }
+        if let Ok(mut handle) = self.handle.lock()
+            && let Some(handle) = handle.take()
+        {
+            drop(handle.join());
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ShardMap {
+    engines: HashMap<TenantId, Arc<ZanzibarEngine>>,
+}
+
+fn default_writer_queue_capacity() -> NonZeroUsize {
+    match NonZeroUsize::new(DEFAULT_WRITER_QUEUE_CAPACITY) {
+        Some(value) => value,
+        None => NonZeroUsize::MIN,
+    }
+}
+
+fn validate_tenant_id(value: &str) -> Result<(), TenantIdError> {
+    if value.is_empty() {
+        return Err(TenantIdError::Empty);
+    }
+    if value.len() > MAX_TENANT_ID_BYTES {
+        return Err(TenantIdError::TooLong {
+            max_bytes: MAX_TENANT_ID_BYTES,
+        });
+    }
+    for (offset, byte) in value.bytes().enumerate() {
+        if !(byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.')) {
+            return Err(TenantIdError::InvalidByte { offset });
+        }
+    }
+    Ok(())
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -228,6 +228,42 @@ impl ZanzibarEngine {
         self.write_relationships_with_preconditions(mutations, [])
     }
 
+    /// Creates one relationship, failing if it already exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the relationship text is invalid, no schema is loaded,
+    /// validation fails, or the relationship already exists.
+    pub fn create_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("create_relationship");
+        let mutation = RelationshipMutation::create(relationship)?;
+        self.write_relationships([mutation])
+    }
+
+    /// Grants or refreshes one relationship idempotently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the relationship text is invalid, no schema is loaded, or
+    /// validation fails.
+    pub fn touch_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("touch_relationship");
+        let mutation = RelationshipMutation::touch(relationship)?;
+        self.write_relationships([mutation])
+    }
+
+    /// Deletes one relationship, failing if it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the relationship text is invalid, no schema is loaded,
+    /// validation fails, or the relationship does not exist.
+    pub fn delete_relationship(&self, relationship: &str) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("delete_relationship");
+        let mutation = RelationshipMutation::delete(relationship)?;
+        self.write_relationships([mutation])
+    }
+
     /// Applies relationship mutations with preconditions and publishes a new revision.
     ///
     /// # Errors

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,9 +14,11 @@ use crate::{
     error::ZanzibarError,
     eval::{EvaluationError, EvaluationLimits},
     model::{
-        CheckRequest, CheckResponse, ExpandRequest, ExpandResponse, LookupResources,
-        LookupResourcesRequest, LookupSubjects, LookupSubjectsRequest,
+        CheckRequest, CheckResponse, ExpandRequest, ExpandResponse, LookupObjectPermissions,
+        LookupObjectPermissionsRequest, LookupPermissions, LookupPermissionsRequest,
+        LookupResources, LookupResourcesRequest, LookupSubjects, LookupSubjectsRequest,
     },
+    policy::{PolicyIoError, PolicyText},
     relationship::{Precondition, RelationshipMutation, StoreError},
     revision::{ConsistencyError, ConsistencyToken, default_retained_snapshots},
     schema::{SchemaError, SchemaSource},
@@ -251,6 +253,138 @@ impl ZanzibarEngine {
         enter_api_span!("apply_schema");
         let mut service = self.write_service("apply_schema")?;
         Ok(service.add_dsl_with_token(source.text)?)
+    }
+
+    /// Replaces the complete schema document and publishes a new revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the schema cannot be parsed or existing relationships no longer
+    /// validate against it.
+    pub fn replace_schema(
+        &self,
+        source: SchemaSource<'_>,
+    ) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("replace_schema");
+        let mut service = self.write_service("replace_schema")?;
+        Ok(service.replace_dsl_with_token(source.text)?)
+    }
+
+    /// Deletes one namespace definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the namespace is missing or existing relationships still
+    /// reference it.
+    pub fn delete_namespace(&self, namespace: &str) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("delete_namespace");
+        let mut service = self.write_service("delete_namespace")?;
+        Ok(service.delete_namespace(namespace)?)
+    }
+
+    /// Deletes one relation definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when the relation is missing or existing relationships still
+    /// reference it.
+    pub fn delete_relation(
+        &self,
+        namespace: &str,
+        relation: &str,
+    ) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("delete_relation");
+        let mut service = self.write_service("delete_relation")?;
+        Ok(service.delete_relation(namespace, relation)?)
+    }
+
+    /// Builds a new engine from policy text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when policy text cannot be parsed or validated.
+    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, EngineError> {
+        enter_api_span!("from_policy_text");
+        Ok(Self {
+            service: RwLock::new(ZanzibarService::from_policy_text(policy)?),
+        })
+    }
+
+    /// Replaces this engine's state with policy text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when policy text cannot be parsed or validated.
+    pub fn apply_policy_text(&self, policy: &PolicyText) -> Result<ConsistencyToken, EngineError> {
+        enter_api_span!("apply_policy_text");
+        let mut service = self.write_service("apply_policy_text")?;
+        Ok(service.apply_policy_text(policy)?)
+    }
+
+    /// Exports the latest state as deterministic policy text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when no schema has been loaded.
+    pub fn export_policy_text(&self) -> Result<PolicyText, EngineError> {
+        enter_api_span!("export_policy_text");
+        let service = self.read_service("export_policy_text")?;
+        Ok(service.export_policy_text()?)
+    }
+
+    /// Exports deterministic policy files under `directory`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyIoError`] when no schema has been loaded, locking fails, or file output
+    /// fails.
+    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError> {
+        enter_api_span!("export_policy_files");
+        let service = self
+            .service
+            .read()
+            .map_err(|_| PolicyIoError::LockPoisoned {
+                operation: "export_policy_files",
+            })?;
+        service.export_policy_files(directory)
+    }
+
+    /// Looks up every relation or permission a subject has on one resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation or evaluation fails.
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "public API follows the request/response ownership contract in \
+                  specs/19-public-api-completeness-design.md"
+    )]
+    pub fn lookup_permissions(
+        &self,
+        request: LookupPermissionsRequest,
+    ) -> Result<LookupPermissions, EngineError> {
+        enter_api_span!("lookup_permissions");
+        let service = self.read_service("lookup_permissions")?;
+        Ok(service.lookup_permissions(&request)?)
+    }
+
+    /// Looks up subjects grouped by every relation or permission they have on one resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError`] when request validation, store access, or evaluation fails.
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "public API follows the request/response ownership contract in \
+                  specs/19-public-api-completeness-design.md"
+    )]
+    pub fn lookup_object_permissions(
+        &self,
+        request: LookupObjectPermissionsRequest,
+    ) -> Result<LookupObjectPermissions, EngineError> {
+        enter_api_span!("lookup_object_permissions");
+        let service = self.read_service("lookup_object_permissions")?;
+        Ok(service.lookup_object_permissions(&request)?)
     }
 
     /// Saves the latest published snapshot to a versioned `.szsnap` artifact.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,8 +1,7 @@
 //! Core evaluation logic for `check` and `expand` requests.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    hash::BuildHasher,
+    collections::{HashSet, VecDeque},
     num::{NonZeroU32, NonZeroUsize},
 };
 
@@ -13,7 +12,7 @@ use crate::{
     error::ZanzibarError,
     model::{
         ExpandedUserset, LookupResources, LookupResourcesRequest, LookupSubjects,
-        LookupSubjectsRequest, NamespaceConfig, Object, Relation, User, UsersetExpression,
+        LookupSubjectsRequest, Object, Relation, User,
     },
     relationship::{
         CompactRelationshipIter, IndexedRelationshipStore, QueryLimit, RelationshipFilter,
@@ -21,7 +20,6 @@ use crate::{
     },
     revision::PublishedSnapshot,
     schema::UsersetExpression as SchemaUsersetExpression,
-    store::TupleStore,
 };
 
 const DEFAULT_MAX_DEPTH: u32 = 50;
@@ -665,153 +663,6 @@ pub fn lookup_subjects_with_snapshot(
     Ok(LookupSubjects { subjects })
 }
 
-fn check_internal<S, C>(
-    object: &Object,
-    relation: &Relation,
-    user: &User,
-    configs: &HashMap<String, NamespaceConfig, C>,
-    store: &(impl TupleStore + ?Sized),
-    visited: &mut HashSet<(Object, Relation, User), S>,
-) -> Result<bool, ZanzibarError>
-where
-    S: BuildHasher,
-    C: BuildHasher,
-{
-    if !visited.insert((object.clone(), relation.clone(), user.clone())) {
-        // We've already seen this exact check in this path, so we're in a cycle.
-        return Ok(false);
-    }
-
-    let config = configs
-        .get(&object.namespace)
-        .ok_or_else(|| ZanzibarError::NamespaceNotFound(object.namespace.clone()))?;
-
-    let relation_config = config
-        .relations
-        .get(relation)
-        .ok_or_else(|| ZanzibarError::RelationNotFound(relation.0.clone(), config.name.clone()))?;
-
-    // If there's a rewrite rule, evaluate it. Otherwise, default to `This`.
-    let rewrite = relation_config
-        .userset_rewrite
-        .as_ref()
-        .unwrap_or(&UsersetExpression::This);
-
-    let result = eval_expression(object, relation, user, configs, store, visited, rewrite);
-
-    // Important: remove the current check from `visited` on the way back up the recursion.
-    visited.remove(&(object.clone(), relation.clone(), user.clone()));
-    result
-}
-
-fn eval_expression<S, C>(
-    object: &Object,
-    relation: &Relation,
-    user: &User,
-    configs: &HashMap<String, NamespaceConfig, C>,
-    store: &(impl TupleStore + ?Sized),
-    visited: &mut HashSet<(Object, Relation, User), S>,
-    expression: &UsersetExpression,
-) -> Result<bool, ZanzibarError>
-where
-    S: BuildHasher,
-    C: BuildHasher,
-{
-    match expression {
-        UsersetExpression::This => {
-            // Direct check: see if the exact tuple exists.
-            let direct_tuples = store.read_tuples(object, Some(relation), Some(user));
-            if !direct_tuples.is_empty() {
-                return Ok(true);
-            }
-
-            // Indirect check: see if the user is in a userset that has the relation.
-            let indirect_tuples = store.read_tuples(object, Some(relation), None);
-            for t in indirect_tuples {
-                if let User::Userset(obj, rel) = t.user {
-                    // Note: a subtle but important detail. When checking a userset,
-                    // we must start a fresh `check` call, not `eval_expression`,
-                    // as the new object (`obj`) may have its own rewrite rules.
-                    if check_internal(&obj, &rel, user, configs, store, visited)? {
-                        return Ok(true);
-                    }
-                }
-            }
-            Ok(false)
-        }
-        UsersetExpression::ComputedUserset {
-            relation: computed_relation,
-        } => {
-            // Similarly, start a fresh `check` to respect the rewrite rules of the new relation.
-            check_internal(object, computed_relation, user, configs, store, visited)
-        }
-        UsersetExpression::TupleToUserset {
-            tupleset_relation,
-            computed_userset_relation,
-        } => {
-            let tupleset = store.read_tuples(object, Some(tupleset_relation), None);
-            for t in tupleset {
-                if let User::Userset(intermediate_obj, _) = t.user
-                    && check_internal(
-                        &intermediate_obj,
-                        computed_userset_relation,
-                        user,
-                        configs,
-                        store,
-                        visited,
-                    )?
-                {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        }
-        UsersetExpression::Union(expressions) => {
-            for expr in expressions {
-                if eval_expression(object, relation, user, configs, store, visited, expr)? {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        }
-        UsersetExpression::Intersection(expressions) => {
-            for expr in expressions {
-                // If any sub-expression is false, the whole intersection is false.
-                if !eval_expression(object, relation, user, configs, store, visited, expr)? {
-                    return Ok(false);
-                }
-            }
-            // If we get here, all sub-expressions were true.
-            Ok(true)
-        }
-        UsersetExpression::Exclusion { base, exclude } => {
-            // If the user is in the `exclude` set, the result is false.
-            let is_excluded =
-                eval_expression(object, relation, user, configs, store, visited, exclude)?;
-            if is_excluded {
-                return Ok(false);
-            }
-            // Otherwise, the result is determined by the `base` set.
-            eval_expression(object, relation, user, configs, store, visited, base)
-        }
-    }
-}
-
-pub(crate) fn check_with_configs<S, C>(
-    object: &Object,
-    relation: &Relation,
-    user: &User,
-    configs: &HashMap<String, NamespaceConfig, C>,
-    store: &(impl TupleStore + ?Sized),
-    visited: &mut HashSet<(Object, Relation, User), S>,
-) -> Result<bool, ZanzibarError>
-where
-    S: BuildHasher,
-    C: BuildHasher,
-{
-    check_internal(object, relation, user, configs, store, visited)
-}
-
 fn indexed_resource_relation<'a>(
     relationships: &'a IndexedRelationshipStore,
     object: &Object,
@@ -923,98 +774,4 @@ fn lookup_result_limit_reached(current_len: usize, limits: EvaluationLimits) -> 
         Err(_) => usize::MAX,
     };
     current_len >= limit
-}
-
-pub(crate) fn expand_with_configs<C>(
-    object: &Object,
-    relation: &Relation,
-    configs: &HashMap<String, NamespaceConfig, C>,
-    store: &(impl TupleStore + ?Sized),
-) -> Result<ExpandedUserset, ZanzibarError>
-where
-    C: BuildHasher,
-{
-    let config = configs
-        .get(&object.namespace)
-        .ok_or_else(|| ZanzibarError::NamespaceNotFound(object.namespace.clone()))?;
-
-    let relation_config = config
-        .relations
-        .get(relation)
-        .ok_or_else(|| ZanzibarError::RelationNotFound(relation.0.clone(), config.name.clone()))?;
-
-    let rewrite = relation_config
-        .userset_rewrite
-        .as_ref()
-        .unwrap_or(&UsersetExpression::This);
-
-    expand_expression(object, relation, configs, store, rewrite)
-}
-
-fn expand_expression<C>(
-    object: &Object,
-    relation: &Relation,
-    configs: &HashMap<String, NamespaceConfig, C>,
-    store: &(impl TupleStore + ?Sized),
-    expression: &UsersetExpression,
-) -> Result<ExpandedUserset, ZanzibarError>
-where
-    C: BuildHasher,
-{
-    match expression {
-        UsersetExpression::This => {
-            let direct_tuples = store.read_tuples(object, Some(relation), None);
-            let mut users = Vec::new();
-            for t in direct_tuples {
-                match t.user {
-                    User::UserId(id) => users.push(ExpandedUserset::User(id)),
-                    User::Userset(obj, rel) => users.push(ExpandedUserset::Userset(obj, rel)),
-                }
-            }
-            Ok(ExpandedUserset::Union(users))
-        }
-        UsersetExpression::ComputedUserset {
-            relation: computed_relation,
-        } => expand_with_configs(object, computed_relation, configs, store),
-        UsersetExpression::TupleToUserset {
-            tupleset_relation,
-            computed_userset_relation,
-        } => {
-            let tupleset = store.read_tuples(object, Some(tupleset_relation), None);
-            let mut users = Vec::new();
-            for t in tupleset {
-                if let User::Userset(intermediate_obj, _) = t.user {
-                    users.push(expand_with_configs(
-                        &intermediate_obj,
-                        computed_userset_relation,
-                        configs,
-                        store,
-                    )?);
-                }
-            }
-            Ok(ExpandedUserset::Union(users))
-        }
-        UsersetExpression::Union(expressions) => {
-            let mut sub_expressions = Vec::new();
-            for expr in expressions {
-                sub_expressions.push(expand_expression(object, relation, configs, store, expr)?);
-            }
-            Ok(ExpandedUserset::Union(sub_expressions))
-        }
-        UsersetExpression::Intersection(expressions) => {
-            let mut sub_expressions = Vec::new();
-            for expr in expressions {
-                sub_expressions.push(expand_expression(object, relation, configs, store, expr)?);
-            }
-            Ok(ExpandedUserset::Intersection(sub_expressions))
-        }
-        UsersetExpression::Exclusion { base, exclude } => {
-            let base_expr = expand_expression(object, relation, configs, store, base)?;
-            let exclude_expr = expand_expression(object, relation, configs, store, exclude)?;
-            Ok(ExpandedUserset::Exclusion {
-                base: Box::new(base_expr),
-                exclude: Box::new(exclude_expr),
-            })
-        }
-    }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -411,12 +411,49 @@ impl<'a> EvaluationContext<'a> {
         base: &SchemaUsersetExpression,
         exclude: &SchemaUsersetExpression,
     ) -> Result<Membership, ZanzibarError> {
+        if self.should_eval_exclude_first(object, exclude) {
+            let exclude_result = self.eval_schema_expression(object, relation, user, exclude)?;
+            if exclude_result == Membership::Allowed {
+                return Ok(Membership::Denied);
+            }
+            let base_result = self.eval_schema_expression(object, relation, user, base)?;
+            return Ok(base_result.exclusion(exclude_result));
+        }
+
         let base = self.eval_schema_expression(object, relation, user, base)?;
         if base == Membership::Denied {
             return Ok(Membership::Denied);
         }
         let exclude = self.eval_schema_expression(object, relation, user, exclude)?;
         Ok(base.exclusion(exclude))
+    }
+
+    fn should_eval_exclude_first(
+        &self,
+        object: &Object,
+        exclude: &SchemaUsersetExpression,
+    ) -> bool {
+        match exclude {
+            SchemaUsersetExpression::This => true,
+            SchemaUsersetExpression::ComputedUserset { relation } => {
+                self.computed_userset_is_plain_relation(object, relation)
+            }
+            SchemaUsersetExpression::TupleToUserset { .. }
+            | SchemaUsersetExpression::Union(_)
+            | SchemaUsersetExpression::Intersection(_)
+            | SchemaUsersetExpression::Exclusion { .. } => false,
+        }
+    }
+
+    fn computed_userset_is_plain_relation(&self, object: &Object, relation: &RelationName) -> bool {
+        let Ok(object_type) = ObjectType::try_from(object.namespace.as_str()) else {
+            return false;
+        };
+        self.snapshot
+            .schema()
+            .resolver()
+            .relation(&object_type, relation)
+            .is_ok_and(|definition| definition.userset_rewrite().is_none())
     }
 
     fn expand_schema_expression(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub mod error;
 pub mod eval;
 pub mod model;
 pub mod parser;
+pub mod policy;
 pub mod relationship;
 pub mod revision;
 pub mod schema;
@@ -87,6 +88,7 @@ use arc_swap::ArcSwapOption;
 
 pub use crate::{
     api::{EngineError, ZanzibarEngine, ZanzibarEngineBuilder},
+    policy::{PolicyIoError, PolicyText, PolicyTextFile},
     snapshot::{
         SnapshotCompression, SnapshotIntegrityMode, SnapshotIoError, SnapshotLoadOptions,
         SnapshotLoadProfile, SnapshotSaveOptions, SnapshotValidationMode,
@@ -96,8 +98,10 @@ use crate::{
     error::ZanzibarError,
     eval::EvaluationLimits,
     model::{
-        LookupResources, LookupResourcesRequest, LookupSubjects, LookupSubjectsRequest,
-        NamespaceConfig, Object, Relation, RelationTuple, User,
+        LookupObjectPermissions, LookupObjectPermissionsRequest, LookupPermissions,
+        LookupPermissionsRequest, LookupResources, LookupResourcesRequest, LookupSubjects,
+        LookupSubjectsRequest, NamespaceConfig, Object, PermissionSubjects, Relation,
+        RelationTuple, User,
     },
     relationship::{
         IndexedRelationshipStore, Precondition, RelationshipFilter, RelationshipMutation,
@@ -187,6 +191,49 @@ impl ZanzibarService {
         self
     }
 
+    /// Builds a new service from canonical or hand-authored policy text.
+    ///
+    /// Relationship files accept one relationship per line. Blank lines and full-line `#` or `//`
+    /// comments are ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError`] when the schema, relationship text, or relationship semantics are
+    /// invalid.
+    pub fn from_policy_text(policy: &PolicyText) -> Result<Self, ZanzibarError> {
+        let mut service = Self::new();
+        service.apply_policy_text(policy)?;
+        Ok(service)
+    }
+
+    /// Replaces this service with the state described by policy text and returns the final token.
+    ///
+    /// The replacement is atomic with respect to validation: if schema parsing or relationship
+    /// application fails, the previous service state remains unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError`] when policy text cannot be parsed or validated.
+    pub fn apply_policy_text(
+        &mut self,
+        policy: &PolicyText,
+    ) -> Result<ConsistencyToken, ZanzibarError> {
+        policy::apply_policy_text_to_service(self, policy)
+    }
+
+    /// Saves a snapshot built from policy text without requiring the caller to keep a service.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyIoError`] when policy parsing or snapshot writing fails.
+    pub fn save_snapshot_from_policy_text(
+        path: impl AsRef<Path>,
+        policy: &PolicyText,
+        options: SnapshotSaveOptions,
+    ) -> Result<(), PolicyIoError> {
+        policy::save_snapshot_from_policy_text(path.as_ref(), policy, options)
+    }
+
     /// Parses a DSL string and adds the resulting configurations to the service.
     ///
     /// # Errors
@@ -213,6 +260,38 @@ impl ZanzibarService {
         self.publish_snapshot(next_configs, compiled_schema, next_relationships)
     }
 
+    /// Replaces the complete schema DSL and publishes a new revision.
+    ///
+    /// Existing relationships are revalidated against the replacement schema. If any relationship
+    /// references a missing namespace or relation, the operation fails and the current state is
+    /// unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError`] when the DSL cannot be parsed or existing relationships do not
+    /// validate against the replacement schema.
+    pub fn replace_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError> {
+        self.replace_dsl_with_token(dsl).map(|_| ())
+    }
+
+    /// Replaces the complete schema DSL and returns a consistency token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError`] when the DSL cannot be parsed or existing relationships do not
+    /// validate against the replacement schema.
+    pub fn replace_dsl_with_token(&mut self, dsl: &str) -> Result<ConsistencyToken, ZanzibarError> {
+        schema::compile_legacy_dsl(dsl)?;
+        let configs = parser::parse_dsl(dsl)?;
+        let next_configs = configs
+            .into_iter()
+            .map(|config| (config.name.clone(), config))
+            .collect::<HashMap<_, _>>();
+        let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
+        let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
+        self.publish_snapshot(next_configs, compiled_schema, next_relationships)
+    }
+
     /// Adds or updates a namespace configuration.
     ///
     /// # Errors
@@ -233,6 +312,60 @@ impl ZanzibarService {
     ) -> Result<ConsistencyToken, ZanzibarError> {
         let mut next_configs = self.configs.clone();
         next_configs.insert(config.name.clone(), config);
+        let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
+        let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
+        self.publish_snapshot(next_configs, compiled_schema, next_relationships)
+    }
+
+    /// Deletes one namespace definition and publishes a new revision.
+    ///
+    /// Existing relationships are revalidated against the candidate schema. If any relationship
+    /// still references the deleted namespace, the operation fails and the current state is
+    /// unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError::NamespaceNotFound`] when the namespace is missing, or another typed
+    /// error when the resulting schema cannot validate existing relationships.
+    pub fn delete_namespace(&mut self, namespace: &str) -> Result<ConsistencyToken, ZanzibarError> {
+        domain::ObjectType::try_from(namespace)?;
+        let mut next_configs = self.configs.clone();
+        if next_configs.remove(namespace).is_none() {
+            return Err(ZanzibarError::NamespaceNotFound(namespace.to_string()));
+        }
+        let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
+        let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
+        self.publish_snapshot(next_configs, compiled_schema, next_relationships)
+    }
+
+    /// Deletes one relation definition and publishes a new revision.
+    ///
+    /// Existing relationships are revalidated against the candidate schema. If any relationship
+    /// still references the deleted relation, the operation fails and the current state is
+    /// unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError::NamespaceNotFound`] or [`ZanzibarError::RelationNotFound`] when the
+    /// target does not exist, or another typed error when existing relationships fail validation.
+    pub fn delete_relation(
+        &mut self,
+        namespace: &str,
+        relation: &str,
+    ) -> Result<ConsistencyToken, ZanzibarError> {
+        domain::ObjectType::try_from(namespace)?;
+        domain::RelationName::try_from(relation)?;
+        let mut next_configs = self.configs.clone();
+        let config = next_configs
+            .get_mut(namespace)
+            .ok_or_else(|| ZanzibarError::NamespaceNotFound(namespace.to_string()))?;
+        let relation_key = Relation(relation.to_string());
+        if config.relations.remove(&relation_key).is_none() {
+            return Err(ZanzibarError::RelationNotFound(
+                relation.to_string(),
+                namespace.to_string(),
+            ));
+        }
         let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
         let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
         self.publish_snapshot(next_configs, compiled_schema, next_relationships)
@@ -506,6 +639,111 @@ impl ZanzibarService {
     ) -> Result<LookupSubjects, ZanzibarError> {
         let snapshot = self.snapshot_for_consistency(consistency)?;
         eval::lookup_subjects_with_snapshot(&snapshot, request, self.evaluation_limits)
+    }
+
+    /// Looks up all relations or permissions a subject has on one resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns typed consistency, domain, schema, or evaluation errors when lookup cannot run.
+    pub fn lookup_permissions(
+        &self,
+        request: &LookupPermissionsRequest,
+    ) -> Result<LookupPermissions, ZanzibarError> {
+        let snapshot = self.snapshot_for_consistency(request.consistency.clone())?;
+        let object_type = domain::ObjectType::try_from(request.resource.namespace.as_str())?;
+        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
+        let mut permissions = Vec::new();
+        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
+        relations.sort_by(|left, right| left.name().cmp(right.name()));
+        for relation_definition in relations {
+            let relation = Relation(relation_definition.name().as_str().to_string());
+            if eval::check_with_snapshot(
+                &snapshot,
+                &request.resource,
+                &relation,
+                &request.subject,
+                self.evaluation_limits,
+            )?
+            .is_allowed()
+            {
+                permissions.push(relation);
+            }
+        }
+        Ok(LookupPermissions { permissions })
+    }
+
+    /// Looks up subjects grouped by every relation or permission they have on one resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns typed consistency, domain, schema, store, or evaluation errors when lookup cannot
+    /// run.
+    pub fn lookup_object_permissions(
+        &self,
+        request: &LookupObjectPermissionsRequest,
+    ) -> Result<LookupObjectPermissions, ZanzibarError> {
+        let snapshot = self.snapshot_for_consistency(request.consistency.clone())?;
+        let object_type = domain::ObjectType::try_from(request.resource.namespace.as_str())?;
+        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
+        let subject_type = domain::SubjectType::try_from(request.subject_type.as_str())?;
+        if subject_type.as_str() != "user" {
+            let subject_object_type = domain::ObjectType::try_from(subject_type.as_str())?;
+            snapshot
+                .schema()
+                .resolver()
+                .namespace(&subject_object_type)?;
+        }
+
+        let mut permissions = Vec::new();
+        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
+        relations.sort_by(|left, right| left.name().cmp(right.name()));
+        for relation_definition in relations {
+            let permission = Relation(relation_definition.name().as_str().to_string());
+            let subjects = eval::lookup_subjects_with_snapshot(
+                &snapshot,
+                &LookupSubjectsRequest {
+                    resource: request.resource.clone(),
+                    permission: permission.clone(),
+                    subject_type: request.subject_type.clone(),
+                },
+                self.evaluation_limits,
+            )?
+            .subjects;
+            if !subjects.is_empty() {
+                permissions.push(PermissionSubjects {
+                    permission,
+                    subjects,
+                });
+            }
+        }
+        Ok(LookupObjectPermissions { permissions })
+    }
+
+    /// Exports the latest snapshot as deterministic reviewable policy text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZanzibarError::SchemaRequired`] when no schema snapshot is loaded.
+    pub fn export_policy_text(&self) -> Result<PolicyText, ZanzibarError> {
+        let snapshot = self
+            .current_snapshot
+            .load_full()
+            .ok_or(ZanzibarError::SchemaRequired)?;
+        Ok(policy::export_policy_text(
+            snapshot.configs(),
+            snapshot.relationships().rows(),
+        ))
+    }
+
+    /// Writes deterministic reviewable policy files under `directory`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyIoError`] when no schema is loaded or file output fails.
+    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError> {
+        let policy = self.export_policy_text()?;
+        policy::write_policy_files(directory.as_ref(), &policy)
     }
 
     /// Saves the latest published snapshot to a versioned `.szsnap` artifact.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@
 //!     RelationTuple, User,
 //! };
 //! use simple_zanzibar::revision::Consistency;
-//! use simple_zanzibar::ZanzibarService;
+//! use simple_zanzibar::ZanzibarEngine;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let mut service = ZanzibarService::new();
+//! let service = ZanzibarEngine::builder().build();
 //! service.add_dsl(
 //!     r"
 //!     namespace doc {
@@ -30,10 +30,10 @@
 //!     user: alice.clone(),
 //! })?;
 //!
-//! assert!(service.check(&doc, &viewer, &alice)?);
+//! assert!(service.check_relation(&doc, &viewer, &alice)?);
 //! assert!(service.check_with_consistency(&doc, &viewer, &alice, Consistency::Exact(token))?);
 //! assert!(matches!(
-//!     service.expand(&doc, &viewer)?,
+//!     service.expand_relation(&doc, &viewer)?,
 //!     ExpandedUserset::Union(_)
 //! ));
 //! assert_eq!(
@@ -72,12 +72,13 @@ pub mod parser;
 pub mod policy;
 pub mod relationship;
 pub mod revision;
+mod runtime;
 pub mod schema;
 pub mod snapshot;
 pub mod store;
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     fmt,
     num::NonZeroUsize,
     path::Path,
@@ -87,7 +88,7 @@ use std::{
 use arc_swap::ArcSwapOption;
 
 pub use crate::{
-    api::{EngineError, ZanzibarEngine, ZanzibarEngineBuilder},
+    api::{EngineError, TenantId, ZanzibarEngine, ZanzibarEngineBuilder, ZanzibarTenantShards},
     policy::{PolicyIoError, PolicyText, PolicyTextFile},
     snapshot::{
         SnapshotCompression, SnapshotIntegrityMode, SnapshotIoError, SnapshotLoadOptions,
@@ -97,31 +98,20 @@ pub use crate::{
 use crate::{
     error::ZanzibarError,
     eval::EvaluationLimits,
-    model::{
-        LookupObjectPermissions, LookupObjectPermissionsRequest, LookupPermissions,
-        LookupPermissionsRequest, LookupResources, LookupResourcesRequest, LookupSubjects,
-        LookupSubjectsRequest, NamespaceConfig, Object, PermissionSubjects, Relation,
-        RelationTuple, User,
-    },
+    model::{NamespaceConfig, Relation},
     relationship::{
         IndexedRelationshipStore, Precondition, RelationshipFilter, RelationshipMutation,
         SubjectFilter,
     },
     revision::{
-        Consistency, ConsistencyError, ConsistencyToken, DatastoreId, PublishedSnapshot, Revision,
-        SchemaHash, default_retained_snapshots,
+        ConsistencyError, ConsistencyToken, DatastoreId, PublishedSnapshot, Revision, SchemaHash,
+        default_retained_snapshots,
     },
+    runtime::{EngineState, SharedEngineState},
     schema::CompiledSchema,
-    store::{InMemoryTupleStore, TupleStore},
 };
 
-/// Compatibility facade for the local Zanzibar engine.
-///
-/// This type preserves the original `ZanzibarService` API while delegating schema-backed reads and
-/// writes to the typed schema, indexed relationship store, and revision snapshot engine. New code
-/// should prefer the request/response methods on this facade; Phase 6 keeps the legacy tuple/config
-/// helpers only as a migration boundary.
-pub struct ZanzibarService {
+pub(crate) struct WriterState {
     configs: HashMap<String, NamespaceConfig>,
     schema: Option<CompiledSchema>,
     relationships: Arc<IndexedRelationshipStore>,
@@ -131,13 +121,13 @@ pub struct ZanzibarService {
     retained_snapshots: NonZeroUsize,
     last_revision: Option<Revision>,
     evaluation_limits: EvaluationLimits,
-    store: Box<dyn TupleStore>,
+    published_state: SharedEngineState,
 }
 
-impl fmt::Debug for ZanzibarService {
+impl fmt::Debug for WriterState {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
-            .debug_struct("ZanzibarService")
+            .debug_struct("WriterState")
             .field("configs", &self.configs)
             .field("schema", &self.schema)
             .field("relationships", &self.relationships)
@@ -147,22 +137,26 @@ impl fmt::Debug for ZanzibarService {
             .field("retained_snapshots", &self.retained_snapshots)
             .field("last_revision", &self.last_revision)
             .field("evaluation_limits", &self.evaluation_limits)
-            .field("store", &"<dyn TupleStore>")
+            .field("published_state", &self.published_state)
             .finish()
     }
 }
 
-impl Default for ZanzibarService {
+impl Default for WriterState {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ZanzibarService {
-    /// Creates a new service with an in-memory store.
+impl WriterState {
     #[must_use]
-    pub fn new() -> Self {
-        ZanzibarService {
+    pub(crate) fn new() -> Self {
+        Self::new_with_publisher(Arc::new(ArcSwapOption::empty()))
+    }
+
+    #[must_use]
+    pub(crate) fn new_with_publisher(published_state: SharedEngineState) -> Self {
+        WriterState {
             configs: HashMap::new(),
             schema: None,
             relationships: Arc::new(IndexedRelationshipStore::default()),
@@ -172,21 +166,29 @@ impl ZanzibarService {
             retained_snapshots: default_retained_snapshots(),
             last_revision: None,
             evaluation_limits: EvaluationLimits::default(),
-            store: Box::new(InMemoryTupleStore::default()),
+            published_state,
         }
     }
 
-    /// Creates a new service with a custom exact-snapshot retention window.
     #[must_use]
-    pub fn with_snapshot_retention(retained_snapshots: NonZeroUsize) -> Self {
+    pub(crate) fn with_snapshot_retention(retained_snapshots: NonZeroUsize) -> Self {
         let mut service = Self::new();
         service.retained_snapshots = retained_snapshots;
         service
     }
 
-    /// Sets evaluation recursion and fanout limits.
     #[must_use]
-    pub fn with_evaluation_limits(mut self, limits: EvaluationLimits) -> Self {
+    pub(crate) fn with_snapshot_retention_and_publisher(
+        retained_snapshots: NonZeroUsize,
+        published_state: SharedEngineState,
+    ) -> Self {
+        let mut service = Self::new_with_publisher(published_state);
+        service.retained_snapshots = retained_snapshots;
+        service
+    }
+
+    #[must_use]
+    pub(crate) fn with_evaluation_limits(mut self, limits: EvaluationLimits) -> Self {
         self.evaluation_limits = limits;
         self
     }
@@ -221,28 +223,6 @@ impl ZanzibarService {
         policy::apply_policy_text_to_service(self, policy)
     }
 
-    /// Saves a snapshot built from policy text without requiring the caller to keep a service.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`PolicyIoError`] when policy parsing or snapshot writing fails.
-    pub fn save_snapshot_from_policy_text(
-        path: impl AsRef<Path>,
-        policy: &PolicyText,
-        options: SnapshotSaveOptions,
-    ) -> Result<(), PolicyIoError> {
-        policy::save_snapshot_from_policy_text(path.as_ref(), policy, options)
-    }
-
-    /// Parses a DSL string and adds the resulting configurations to the service.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::ParseError`] when the DSL cannot be parsed.
-    pub fn add_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError> {
-        self.add_dsl_with_token(dsl).map(|_| ())
-    }
-
     /// Parses a DSL string, adds the resulting configurations, and returns a consistency token.
     ///
     /// # Errors
@@ -251,6 +231,13 @@ impl ZanzibarService {
     pub fn add_dsl_with_token(&mut self, dsl: &str) -> Result<ConsistencyToken, ZanzibarError> {
         schema::compile_legacy_dsl(dsl)?;
         let configs = parser::parse_dsl(dsl)?;
+        self.apply_namespace_configs(configs)
+    }
+
+    pub(crate) fn apply_namespace_configs(
+        &mut self,
+        configs: impl IntoIterator<Item = NamespaceConfig>,
+    ) -> Result<ConsistencyToken, ZanzibarError> {
         let mut next_configs = self.configs.clone();
         for config in configs {
             next_configs.insert(config.name.clone(), config);
@@ -258,20 +245,6 @@ impl ZanzibarService {
         let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
         let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
         self.publish_snapshot(next_configs, compiled_schema, next_relationships)
-    }
-
-    /// Replaces the complete schema DSL and publishes a new revision.
-    ///
-    /// Existing relationships are revalidated against the replacement schema. If any relationship
-    /// references a missing namespace or relation, the operation fails and the current state is
-    /// unchanged.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError`] when the DSL cannot be parsed or existing relationships do not
-    /// validate against the replacement schema.
-    pub fn replace_dsl(&mut self, dsl: &str) -> Result<(), ZanzibarError> {
-        self.replace_dsl_with_token(dsl).map(|_| ())
     }
 
     /// Replaces the complete schema DSL and returns a consistency token.
@@ -287,31 +260,6 @@ impl ZanzibarService {
             .into_iter()
             .map(|config| (config.name.clone(), config))
             .collect::<HashMap<_, _>>();
-        let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
-        let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
-        self.publish_snapshot(next_configs, compiled_schema, next_relationships)
-    }
-
-    /// Adds or updates a namespace configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::Schema`] when the updated schema does not validate.
-    pub fn add_config(&mut self, config: NamespaceConfig) -> Result<(), ZanzibarError> {
-        self.add_config_with_token(config).map(|_| ())
-    }
-
-    /// Adds or updates a namespace configuration and returns a consistency token.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::Schema`] when the updated schema does not validate.
-    pub fn add_config_with_token(
-        &mut self,
-        config: NamespaceConfig,
-    ) -> Result<ConsistencyToken, ZanzibarError> {
-        let mut next_configs = self.configs.clone();
-        next_configs.insert(config.name.clone(), config);
         let compiled_schema = schema::compile_legacy_configs(next_configs.values().cloned())?;
         let next_relationships = self.relationship_store_for_schema(&compiled_schema)?;
         self.publish_snapshot(next_configs, compiled_schema, next_relationships)
@@ -371,67 +319,7 @@ impl ZanzibarService {
         self.publish_snapshot(next_configs, compiled_schema, next_relationships)
     }
 
-    /// Writes a relation tuple to the store.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::StorageError`] when the underlying store rejects the write.
-    pub fn write_tuple(&mut self, tuple: RelationTuple) -> Result<(), ZanzibarError> {
-        if self.schema.is_some() {
-            return self.write_tuple_with_token(&tuple).map(|_| ());
-        }
-
-        self.store
-            .write_tuple(tuple)
-            .map_err(ZanzibarError::StorageError)
-    }
-
-    /// Writes a relation tuple and returns a consistency token.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded.
-    pub fn write_tuple_with_token(
-        &mut self,
-        tuple: &RelationTuple,
-    ) -> Result<ConsistencyToken, ZanzibarError> {
-        let relationship = domain::Relationship::try_from(tuple)?;
-        self.apply_relationship_mutations([RelationshipMutation::Create(relationship)], [])
-    }
-
     /// Applies a validated batch of relationship mutations.
-    ///
-    /// ```
-    /// use simple_zanzibar::domain::Relationship;
-    /// use simple_zanzibar::relationship::{
-    ///     Precondition, RelationshipFilter, RelationshipMutation, SubjectFilter,
-    /// };
-    /// use simple_zanzibar::ZanzibarService;
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let mut service = ZanzibarService::new();
-    /// service.add_dsl(
-    ///     r"
-    ///     namespace doc {
-    ///         relation viewer {}
-    ///     }
-    ///     ",
-    /// )?;
-    ///
-    /// let relationship: Relationship = "doc:readme#viewer@user:alice".parse()?;
-    /// let subject = SubjectFilter::exact("user".try_into()?, "alice".try_into()?, None);
-    /// let precondition = Precondition::MustNotMatch(RelationshipFilter::for_exact_subject(
-    ///     relationship.resource(),
-    ///     relationship.relation().clone(),
-    ///     subject,
-    /// ));
-    /// service.apply_relationship_mutations(
-    ///     [RelationshipMutation::Touch(relationship)],
-    ///     [precondition],
-    /// )?;
-    /// # Ok(())
-    /// # }
-    /// ```
     ///
     /// # Errors
     ///
@@ -458,294 +346,6 @@ impl ZanzibarService {
         self.publish_snapshot(self.configs.clone(), schema, Arc::new(candidate))
     }
 
-    /// Deletes a relation tuple from the store.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::StorageError`] when the underlying store rejects the delete.
-    pub fn delete_tuple(&mut self, tuple: &RelationTuple) -> Result<(), ZanzibarError> {
-        if self.schema.is_some() {
-            return self.delete_tuple_with_token(tuple).map(|_| ());
-        }
-
-        self.store
-            .delete_tuple(tuple)
-            .map_err(ZanzibarError::StorageError)
-    }
-
-    /// Deletes a relation tuple and returns a consistency token.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded.
-    pub fn delete_tuple_with_token(
-        &mut self,
-        tuple: &RelationTuple,
-    ) -> Result<ConsistencyToken, ZanzibarError> {
-        let relationship = domain::Relationship::try_from(tuple)?;
-        self.apply_relationship_mutations([RelationshipMutation::Delete(relationship)], [])
-    }
-
-    /// Checks if a user has a specific relation to an object.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::NamespaceNotFound`] when the object's namespace has not been
-    /// configured, or [`ZanzibarError::RelationNotFound`] when the relation is missing from that
-    /// namespace.
-    pub fn check(
-        &self,
-        object: &Object,
-        relation: &Relation,
-        user: &User,
-    ) -> Result<bool, ZanzibarError> {
-        if self.schema.is_some() {
-            return self.check_with_consistency(object, relation, user, Consistency::Latest);
-        }
-
-        if !self.configs.contains_key(&object.namespace) {
-            return Err(ZanzibarError::NamespaceNotFound(object.namespace.clone()));
-        }
-
-        eval::check_with_configs(
-            object,
-            relation,
-            user,
-            &self.configs,
-            self.store.as_ref(),
-            &mut HashSet::new(),
-        )
-    }
-
-    /// Checks if a user has a relation to an object at the requested consistency.
-    ///
-    /// # Errors
-    ///
-    /// Returns typed consistency, domain, schema, or evaluation errors when the check cannot run.
-    pub fn check_with_consistency(
-        &self,
-        object: &Object,
-        relation: &Relation,
-        user: &User,
-        consistency: Consistency,
-    ) -> Result<bool, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(consistency)?;
-        let resource = domain::ObjectRef::try_from(object)?;
-        let relation_name = domain::RelationName::try_from(relation.0.as_str())?;
-        snapshot
-            .schema()
-            .resolver()
-            .relation(resource.object_type(), &relation_name)?;
-        Ok(
-            eval::check_with_snapshot(&snapshot, object, relation, user, self.evaluation_limits)?
-                .is_allowed(),
-        )
-    }
-
-    /// Expands the userset for a given object and relation.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::NamespaceNotFound`] when the object's namespace has not been
-    /// configured, or [`ZanzibarError::RelationNotFound`] when the relation is missing from that
-    /// namespace.
-    pub fn expand(
-        &self,
-        object: &Object,
-        relation: &Relation,
-    ) -> Result<model::ExpandedUserset, ZanzibarError> {
-        if self.schema.is_some() {
-            return self.expand_with_consistency(object, relation, Consistency::Latest);
-        }
-
-        if !self.configs.contains_key(&object.namespace) {
-            return Err(ZanzibarError::NamespaceNotFound(object.namespace.clone()));
-        }
-        eval::expand_with_configs(object, relation, &self.configs, self.store.as_ref())
-    }
-
-    /// Expands the userset for a given object and relation at the requested consistency.
-    ///
-    /// # Errors
-    ///
-    /// Returns typed consistency, domain, schema, or evaluation errors when the expand cannot run.
-    pub fn expand_with_consistency(
-        &self,
-        object: &Object,
-        relation: &Relation,
-        consistency: Consistency,
-    ) -> Result<model::ExpandedUserset, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(consistency)?;
-        let object_type = domain::ObjectType::try_from(object.namespace.as_str())?;
-        let relation_name = domain::RelationName::try_from(relation.0.as_str())?;
-        snapshot
-            .schema()
-            .resolver()
-            .relation(&object_type, &relation_name)?;
-        eval::expand_with_snapshot(&snapshot, object, relation, self.evaluation_limits)
-    }
-
-    /// Looks up resources of a type that the request subject can access.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded, or typed
-    /// consistency, domain, schema, store, or evaluation errors when lookup cannot run.
-    pub fn lookup_resources(
-        &self,
-        request: &LookupResourcesRequest,
-    ) -> Result<LookupResources, ZanzibarError> {
-        self.lookup_resources_with_consistency(request, Consistency::Latest)
-    }
-
-    /// Looks up resources of a type at the requested consistency.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded, or typed
-    /// consistency, domain, schema, store, or evaluation errors when lookup cannot run.
-    pub fn lookup_resources_with_consistency(
-        &self,
-        request: &LookupResourcesRequest,
-        consistency: Consistency,
-    ) -> Result<LookupResources, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(consistency)?;
-        eval::lookup_resources_with_snapshot(&snapshot, request, self.evaluation_limits)
-    }
-
-    /// Looks up subjects of a type that can access the request resource.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded, or typed
-    /// consistency, domain, schema, store, or evaluation errors when lookup cannot run.
-    pub fn lookup_subjects(
-        &self,
-        request: &LookupSubjectsRequest,
-    ) -> Result<LookupSubjects, ZanzibarError> {
-        self.lookup_subjects_with_consistency(request, Consistency::Latest)
-    }
-
-    /// Looks up subjects of a type at the requested consistency.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema has been loaded, or typed
-    /// consistency, domain, schema, store, or evaluation errors when lookup cannot run.
-    pub fn lookup_subjects_with_consistency(
-        &self,
-        request: &LookupSubjectsRequest,
-        consistency: Consistency,
-    ) -> Result<LookupSubjects, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(consistency)?;
-        eval::lookup_subjects_with_snapshot(&snapshot, request, self.evaluation_limits)
-    }
-
-    /// Looks up all relations or permissions a subject has on one resource.
-    ///
-    /// # Errors
-    ///
-    /// Returns typed consistency, domain, schema, or evaluation errors when lookup cannot run.
-    pub fn lookup_permissions(
-        &self,
-        request: &LookupPermissionsRequest,
-    ) -> Result<LookupPermissions, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(request.consistency.clone())?;
-        let object_type = domain::ObjectType::try_from(request.resource.namespace.as_str())?;
-        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
-        let mut permissions = Vec::new();
-        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
-        relations.sort_by(|left, right| left.name().cmp(right.name()));
-        for relation_definition in relations {
-            let relation = Relation(relation_definition.name().as_str().to_string());
-            if eval::check_with_snapshot(
-                &snapshot,
-                &request.resource,
-                &relation,
-                &request.subject,
-                self.evaluation_limits,
-            )?
-            .is_allowed()
-            {
-                permissions.push(relation);
-            }
-        }
-        Ok(LookupPermissions { permissions })
-    }
-
-    /// Looks up subjects grouped by every relation or permission they have on one resource.
-    ///
-    /// # Errors
-    ///
-    /// Returns typed consistency, domain, schema, store, or evaluation errors when lookup cannot
-    /// run.
-    pub fn lookup_object_permissions(
-        &self,
-        request: &LookupObjectPermissionsRequest,
-    ) -> Result<LookupObjectPermissions, ZanzibarError> {
-        let snapshot = self.snapshot_for_consistency(request.consistency.clone())?;
-        let object_type = domain::ObjectType::try_from(request.resource.namespace.as_str())?;
-        let namespace = snapshot.schema().resolver().namespace(&object_type)?;
-        let subject_type = domain::SubjectType::try_from(request.subject_type.as_str())?;
-        if subject_type.as_str() != "user" {
-            let subject_object_type = domain::ObjectType::try_from(subject_type.as_str())?;
-            snapshot
-                .schema()
-                .resolver()
-                .namespace(&subject_object_type)?;
-        }
-
-        let mut permissions = Vec::new();
-        let mut relations = namespace.relations().iter().collect::<Vec<_>>();
-        relations.sort_by(|left, right| left.name().cmp(right.name()));
-        for relation_definition in relations {
-            let permission = Relation(relation_definition.name().as_str().to_string());
-            let subjects = eval::lookup_subjects_with_snapshot(
-                &snapshot,
-                &LookupSubjectsRequest {
-                    resource: request.resource.clone(),
-                    permission: permission.clone(),
-                    subject_type: request.subject_type.clone(),
-                },
-                self.evaluation_limits,
-            )?
-            .subjects;
-            if !subjects.is_empty() {
-                permissions.push(PermissionSubjects {
-                    permission,
-                    subjects,
-                });
-            }
-        }
-        Ok(LookupObjectPermissions { permissions })
-    }
-
-    /// Exports the latest snapshot as deterministic reviewable policy text.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ZanzibarError::SchemaRequired`] when no schema snapshot is loaded.
-    pub fn export_policy_text(&self) -> Result<PolicyText, ZanzibarError> {
-        let snapshot = self
-            .current_snapshot
-            .load_full()
-            .ok_or(ZanzibarError::SchemaRequired)?;
-        Ok(policy::export_policy_text(
-            snapshot.configs(),
-            snapshot.relationships().rows(),
-        ))
-    }
-
-    /// Writes deterministic reviewable policy files under `directory`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`PolicyIoError`] when no schema is loaded or file output fails.
-    pub fn export_policy_files(&self, directory: impl AsRef<Path>) -> Result<(), PolicyIoError> {
-        let policy = self.export_policy_text()?;
-        policy::write_policy_files(directory.as_ref(), &policy)
-    }
-
     /// Saves the latest published snapshot to a versioned `.szsnap` artifact.
     ///
     /// Snapshot artifacts are deterministic for the same published snapshot and are intended for
@@ -770,20 +370,10 @@ impl ZanzibarService {
         snapshot::save_snapshot_file(path.as_ref(), &snapshot, options)
     }
 
-    /// Loads a versioned `.szsnap` artifact into a new service instance.
-    ///
-    /// The loaded service receives a new datastore id, so consistency tokens from the writer
-    /// process are intentionally rejected. The artifact revision becomes the loaded service's
-    /// latest revision, and the exact-snapshot history contains only that one snapshot until later
-    /// writes publish new revisions.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SnapshotIoError`] when the file cannot be read, exceeds the configured byte cap,
-    /// fails format validation, has a bad checksum, or contains invalid schema/relationship data.
-    pub fn load_snapshot(
+    pub(crate) fn load_snapshot_with_publisher(
         path: impl AsRef<Path>,
         options: SnapshotLoadOptions,
+        published_state: SharedEngineState,
     ) -> Result<Self, SnapshotIoError> {
         let loaded = snapshot::load_snapshot_file(path.as_ref(), options)?;
         let snapshot = Arc::new(PublishedSnapshot::new(
@@ -793,13 +383,17 @@ impl ZanzibarService {
             Arc::new(loaded.schema.clone()),
             Arc::clone(&loaded.relationships),
         ));
-        let mut service = Self::with_snapshot_retention(snapshot::one_snapshot_retention());
+        let mut service = Self::with_snapshot_retention_and_publisher(
+            snapshot::one_snapshot_retention(),
+            published_state,
+        );
         service.configs = loaded.configs;
         service.schema = Some(loaded.schema);
         service.relationships = loaded.relationships;
         service.current_snapshot.store(Some(Arc::clone(&snapshot)));
         service.snapshot_history.push_back(snapshot);
         service.last_revision = Some(loaded.revision);
+        service.publish_current_engine_state();
         Ok(service)
     }
 
@@ -810,7 +404,7 @@ impl ZanzibarService {
         if self.schema.is_some() {
             return self.revalidate_relationship_store(schema);
         }
-        self.rebuild_relationship_store_from_legacy_tuples(schema)
+        Ok(Arc::new(IndexedRelationshipStore::default()))
     }
 
     fn revalidate_relationship_store(
@@ -819,19 +413,6 @@ impl ZanzibarService {
     ) -> Result<Arc<IndexedRelationshipStore>, ZanzibarError> {
         let mut relationships = IndexedRelationshipStore::default();
         for relationship in self.relationships.rows() {
-            schema.validate_relationship(&relationship)?;
-            relationships.apply_mutations([RelationshipMutation::Touch(relationship)], [])?;
-        }
-        Ok(Arc::new(relationships))
-    }
-
-    fn rebuild_relationship_store_from_legacy_tuples(
-        &self,
-        schema: &CompiledSchema,
-    ) -> Result<Arc<IndexedRelationshipStore>, ZanzibarError> {
-        let mut relationships = IndexedRelationshipStore::default();
-        for tuple in self.store.all_tuples() {
-            let relationship = domain::Relationship::try_from(&tuple)?;
             schema.validate_relationship(&relationship)?;
             relationships.apply_mutations([RelationshipMutation::Touch(relationship)], [])?;
         }
@@ -858,69 +439,40 @@ impl ZanzibarService {
         self.configs = configs;
         self.schema = Some(schema);
         self.relationships = relationships;
-        self.store.replace_all(Vec::new());
         self.current_snapshot.store(Some(Arc::clone(&snapshot)));
         self.snapshot_history.push_back(snapshot);
         while self.snapshot_history.len() > self.retained_snapshots.get() {
             self.snapshot_history.pop_front();
         }
         self.last_revision = Some(revision);
+        self.publish_current_engine_state();
         Ok(token)
+    }
+
+    pub(crate) fn replace_publisher(&mut self, published_state: SharedEngineState) {
+        self.published_state = published_state;
+        self.publish_current_engine_state();
+    }
+
+    fn publish_current_engine_state(&self) {
+        match (self.current_snapshot.load_full(), self.last_revision) {
+            (Some(snapshot), Some(revision)) => {
+                self.published_state.store(Some(Arc::new(EngineState::new(
+                    snapshot,
+                    self.snapshot_history.clone(),
+                    self.datastore_id,
+                    revision,
+                    self.evaluation_limits,
+                ))));
+            }
+            _ => self.published_state.store(None),
+        }
     }
 
     fn next_revision(&self) -> Result<Revision, ConsistencyError> {
         match self.last_revision {
             Some(revision) => revision.next(),
             None => Ok(Revision::first()),
-        }
-    }
-
-    fn snapshot_for_consistency(
-        &self,
-        consistency: Consistency,
-    ) -> Result<Arc<PublishedSnapshot>, ZanzibarError> {
-        match consistency {
-            Consistency::Latest => self
-                .current_snapshot
-                .load_full()
-                .ok_or(ZanzibarError::SchemaRequired),
-            Consistency::Exact(token) => {
-                if token.datastore_id() != self.datastore_id {
-                    return Err(ConsistencyError::WrongDatastore.into());
-                }
-                if self
-                    .last_revision
-                    .is_none_or(|latest| token.revision() > latest)
-                {
-                    return Err(ConsistencyError::RevisionUnavailable {
-                        revision: token.revision(),
-                    }
-                    .into());
-                }
-                if let Some(oldest) = self.snapshot_history.front()
-                    && token.revision() < oldest.revision()
-                {
-                    return Err(ConsistencyError::RevisionExpired {
-                        revision: token.revision(),
-                    }
-                    .into());
-                }
-                let snapshot = self
-                    .snapshot_history
-                    .iter()
-                    .find(|snapshot| snapshot.revision() == token.revision())
-                    .cloned()
-                    .ok_or(ConsistencyError::RevisionUnavailable {
-                        revision: token.revision(),
-                    })?;
-                if snapshot.schema_hash() != token.schema_hash() {
-                    return Err(ConsistencyError::SchemaHashMismatch {
-                        revision: token.revision(),
-                    }
-                    .into());
-                }
-                Ok(snapshot)
-            }
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -243,6 +243,76 @@ pub struct LookupSubjects {
     pub subjects: Vec<User>,
 }
 
+/// Request for all permissions a subject has on one resource.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupPermissionsRequest {
+    /// Subject whose permissions are requested.
+    pub subject: User,
+    /// Resource object to evaluate.
+    pub resource: Object,
+    /// Consistency selector for the read.
+    pub consistency: Consistency,
+}
+
+/// Permissions returned by a subject/resource lookup request.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupPermissions {
+    /// Sorted relations or permissions that evaluated to allowed.
+    pub permissions: Vec<Relation>,
+}
+
+/// Request for subjects grouped by every permission they have on one resource.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupObjectPermissionsRequest {
+    /// Resource object to evaluate.
+    pub resource: Object,
+    /// Subject namespace/type to return.
+    pub subject_type: String,
+    /// Consistency selector for the read.
+    pub consistency: Consistency,
+}
+
+/// Subjects grouped by permission for one resource.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookupObjectPermissions {
+    /// Permission groups with non-empty subjects.
+    pub permissions: Vec<PermissionSubjects>,
+}
+
+/// Subjects that have one permission on a resource.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionSubjects {
+    /// Relation or permission name.
+    pub permission: Relation,
+    /// Subjects that passed the shared check evaluator.
+    pub subjects: Vec<User>,
+}
+
 /// Defines the schema and policy rules for a particular namespace.
 #[cfg_attr(
     feature = "serde",

--- a/src/model.rs
+++ b/src/model.rs
@@ -203,6 +203,18 @@ pub struct LookupResourcesRequest {
     pub resource_type: String,
 }
 
+impl LookupResourcesRequest {
+    /// Creates a request to list resources of one type that a subject can access.
+    #[must_use]
+    pub fn new(subject: User, permission: Relation, resource_type: impl Into<String>) -> Self {
+        Self {
+            subject,
+            permission,
+            resource_type: resource_type.into(),
+        }
+    }
+}
+
 /// Resources returned by a lookup request.
 #[cfg_attr(
     feature = "serde",
@@ -229,6 +241,18 @@ pub struct LookupSubjectsRequest {
     pub permission: Relation,
     /// Subject namespace/type to return.
     pub subject_type: String,
+}
+
+impl LookupSubjectsRequest {
+    /// Creates a request to list subjects of one type that can access a resource.
+    #[must_use]
+    pub fn new(resource: Object, permission: Relation, subject_type: impl Into<String>) -> Self {
+        Self {
+            resource,
+            permission,
+            subject_type: subject_type.into(),
+        }
+    }
 }
 
 /// Subjects returned by a lookup request.
@@ -259,6 +283,18 @@ pub struct LookupPermissionsRequest {
     pub consistency: Consistency,
 }
 
+impl LookupPermissionsRequest {
+    /// Creates a request to list all relations or permissions one subject has on one resource.
+    #[must_use]
+    pub fn new(subject: User, resource: Object, consistency: Consistency) -> Self {
+        Self {
+            subject,
+            resource,
+            consistency,
+        }
+    }
+}
+
 /// Permissions returned by a subject/resource lookup request.
 #[cfg_attr(
     feature = "serde",
@@ -285,6 +321,22 @@ pub struct LookupObjectPermissionsRequest {
     pub subject_type: String,
     /// Consistency selector for the read.
     pub consistency: Consistency,
+}
+
+impl LookupObjectPermissionsRequest {
+    /// Creates a request to list subjects grouped by each relation or permission on a resource.
+    #[must_use]
+    pub fn new(
+        resource: Object,
+        subject_type: impl Into<String>,
+        consistency: Consistency,
+    ) -> Self {
+        Self {
+            resource,
+            subject_type: subject_type.into(),
+            consistency,
+        }
+    }
 }
 
 /// Subjects grouped by permission for one resource.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,329 @@
+//! Policy text import/export helpers.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs, io,
+    path::Path,
+};
+
+use thiserror::Error;
+
+use crate::{
+    domain::Relationship,
+    error::ZanzibarError,
+    model::{NamespaceConfig, RelationConfig, UsersetExpression},
+    snapshot::{SnapshotIoError, SnapshotSaveOptions},
+};
+
+const SCHEMA_FILE_NAME: &str = "schema.zed";
+const RELATIONSHIP_DIRECTORY_NAME: &str = "relationships";
+const RELATIONSHIP_FILE_EXTENSION: &str = "zedtuples";
+
+/// Complete reviewable policy text.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyText {
+    /// Canonical schema DSL.
+    pub schema: String,
+    /// Grouped relationship text files.
+    pub relationship_files: Vec<PolicyTextFile>,
+}
+
+impl PolicyText {
+    /// Creates policy text from schema and grouped relationship files.
+    #[must_use]
+    pub fn new(schema: String, relationship_files: Vec<PolicyTextFile>) -> Self {
+        Self {
+            schema,
+            relationship_files,
+        }
+    }
+
+    /// Creates policy text with all relationships in one logical file.
+    #[must_use]
+    pub fn from_single_relationship_file(schema: String, relationships: String) -> Self {
+        Self {
+            schema,
+            relationship_files: vec![PolicyTextFile {
+                path: format!("{RELATIONSHIP_DIRECTORY_NAME}/all.{RELATIONSHIP_FILE_EXTENSION}"),
+                contents: relationships,
+            }],
+        }
+    }
+}
+
+/// One reviewable policy text file.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyTextFile {
+    /// Relative file path used when exporting to a directory.
+    pub path: String,
+    /// File contents.
+    pub contents: String,
+}
+
+/// Errors produced while importing or exporting policy files.
+#[derive(Debug, Error)]
+pub enum PolicyIoError {
+    /// Filesystem I/O failed.
+    #[error("policy io failed")]
+    Io {
+        /// Source I/O error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// Policy parsing, validation, or mutation failed.
+    #[error("policy operation failed")]
+    Zanzibar {
+        /// Source Zanzibar error.
+        #[source]
+        source: ZanzibarError,
+    },
+
+    /// Snapshot save/load failed while processing policy text.
+    #[error("policy snapshot operation failed")]
+    Snapshot {
+        /// Source snapshot error.
+        #[source]
+        source: SnapshotIoError,
+    },
+
+    /// The export path was invalid for policy file output.
+    #[error("policy export path is invalid: {reason}")]
+    InvalidExportPath {
+        /// Static invalid path reason.
+        reason: &'static str,
+    },
+
+    /// An engine lock was poisoned before policy IO could run.
+    #[error("engine lock poisoned during {operation}")]
+    LockPoisoned {
+        /// Operation that attempted to acquire the poisoned lock.
+        operation: &'static str,
+    },
+}
+
+impl From<io::Error> for PolicyIoError {
+    fn from(source: io::Error) -> Self {
+        Self::Io { source }
+    }
+}
+
+impl From<ZanzibarError> for PolicyIoError {
+    fn from(source: ZanzibarError) -> Self {
+        Self::Zanzibar { source }
+    }
+}
+
+impl From<SnapshotIoError> for PolicyIoError {
+    fn from(source: SnapshotIoError) -> Self {
+        Self::Snapshot { source }
+    }
+}
+
+pub(crate) fn canonical_schema_source(configs: &HashMap<String, NamespaceConfig>) -> String {
+    let mut output = String::new();
+    let mut namespaces = configs.values().collect::<Vec<_>>();
+    namespaces.sort_by(|left, right| left.name.cmp(&right.name));
+    for namespace in namespaces {
+        output.push_str("namespace ");
+        output.push_str(&namespace.name);
+        output.push_str(" {\n");
+        let mut relations = namespace.relations.values().collect::<Vec<_>>();
+        relations.sort_by(|left, right| left.name.0.cmp(&right.name.0));
+        for relation in relations {
+            push_relation(&mut output, relation);
+        }
+        output.push_str("}\n\n");
+    }
+    output
+}
+
+pub(crate) fn export_policy_text(
+    configs: &HashMap<String, NamespaceConfig>,
+    relationships: Vec<Relationship>,
+) -> PolicyText {
+    PolicyText {
+        schema: canonical_schema_source(configs),
+        relationship_files: relationship_files(relationships),
+    }
+}
+
+pub(crate) fn write_policy_files(
+    directory: &Path,
+    policy: &PolicyText,
+) -> Result<(), PolicyIoError> {
+    if directory.as_os_str().is_empty() {
+        return Err(PolicyIoError::InvalidExportPath {
+            reason: "directory path must not be empty",
+        });
+    }
+
+    fs::create_dir_all(directory)?;
+    fs::write(directory.join(SCHEMA_FILE_NAME), policy.schema.as_bytes())?;
+    let relationship_directory = directory.join(RELATIONSHIP_DIRECTORY_NAME);
+    fs::create_dir_all(&relationship_directory)?;
+    for file in &policy.relationship_files {
+        let relative = Path::new(&file.path);
+        if relative.is_absolute() || relative.components().any(is_parent_component) {
+            return Err(PolicyIoError::InvalidExportPath {
+                reason: "policy file path must be relative and stay inside the export directory",
+            });
+        }
+        fs::write(directory.join(relative), file.contents.as_bytes())?;
+    }
+    Ok(())
+}
+
+pub(crate) fn apply_policy_text_to_service(
+    service: &mut crate::ZanzibarService,
+    policy: &PolicyText,
+) -> Result<crate::revision::ConsistencyToken, ZanzibarError> {
+    let mut candidate = crate::ZanzibarService::with_snapshot_retention(service.retained_snapshots)
+        .with_evaluation_limits(service.evaluation_limits);
+    candidate.datastore_id = service.datastore_id;
+    candidate.last_revision = service.last_revision;
+    let mut token = candidate.replace_dsl_with_token(&policy.schema)?;
+    let mut mutations = Vec::with_capacity(policy_import_batch_size());
+    for relationship in parse_relationships(policy)? {
+        mutations.push(crate::relationship::RelationshipMutation::Create(
+            relationship,
+        ));
+        if mutations.len() == policy_import_batch_size() {
+            token = candidate.apply_relationship_mutations(std::mem::take(&mut mutations), [])?;
+        }
+    }
+    if !mutations.is_empty() {
+        token = candidate.apply_relationship_mutations(mutations, [])?;
+    }
+    *service = candidate;
+    Ok(token)
+}
+
+pub(crate) fn save_snapshot_from_policy_text(
+    path: &Path,
+    policy: &PolicyText,
+    options: SnapshotSaveOptions,
+) -> Result<(), PolicyIoError> {
+    let service = crate::ZanzibarService::from_policy_text(policy)?;
+    service.save_snapshot(path, options)?;
+    Ok(())
+}
+
+fn relationship_files(relationships: Vec<Relationship>) -> Vec<PolicyTextFile> {
+    let mut groups = BTreeMap::<String, Vec<String>>::new();
+    for relationship in relationships {
+        groups
+            .entry(relationship.resource().object_type().as_str().to_string())
+            .or_default()
+            .push(relationship.to_string());
+    }
+
+    groups
+        .into_iter()
+        .map(|(resource_type, mut lines)| {
+            lines.sort();
+            let mut contents = lines.join("\n");
+            if !contents.is_empty() {
+                contents.push('\n');
+            }
+            PolicyTextFile {
+                path: format!(
+                    "{RELATIONSHIP_DIRECTORY_NAME}/{resource_type}.{RELATIONSHIP_FILE_EXTENSION}",
+                ),
+                contents,
+            }
+        })
+        .collect()
+}
+
+fn parse_relationships(policy: &PolicyText) -> Result<Vec<Relationship>, ZanzibarError> {
+    let mut relationships = Vec::new();
+    for file in &policy.relationship_files {
+        for line in file.contents.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+                continue;
+            }
+            relationships.push(trimmed.parse()?);
+        }
+    }
+    Ok(relationships)
+}
+
+fn push_relation(output: &mut String, relation: &RelationConfig) {
+    if let Some(expression) = &relation.userset_rewrite {
+        output.push_str("    relation ");
+        output.push_str(&relation.name.0);
+        output.push_str(" {\n        rewrite ");
+        push_expression(output, expression);
+        output.push_str("\n    }\n");
+    } else {
+        output.push_str("    relation ");
+        output.push_str(&relation.name.0);
+        output.push_str(" {}\n");
+    }
+}
+
+fn push_expression(output: &mut String, expression: &UsersetExpression) {
+    match expression {
+        UsersetExpression::This => output.push_str("this"),
+        UsersetExpression::ComputedUserset { relation } => {
+            output.push_str("computed_userset(relation: \"");
+            output.push_str(&relation.0);
+            output.push_str("\")");
+        }
+        UsersetExpression::TupleToUserset {
+            tupleset_relation,
+            computed_userset_relation,
+        } => {
+            output.push_str("tuple_to_userset(tupleset: \"");
+            output.push_str(&tupleset_relation.0);
+            output.push_str("\", computed_userset: \"");
+            output.push_str(&computed_userset_relation.0);
+            output.push_str("\")");
+        }
+        UsersetExpression::Union(expressions) => {
+            push_expression_list(output, "union", expressions);
+        }
+        UsersetExpression::Intersection(expressions) => {
+            push_expression_list(output, "intersection", expressions);
+        }
+        UsersetExpression::Exclusion { base, exclude } => {
+            output.push_str("exclusion(");
+            push_expression(output, base);
+            output.push_str(", ");
+            push_expression(output, exclude);
+            output.push(')');
+        }
+    }
+}
+
+fn push_expression_list(output: &mut String, name: &str, expressions: &[UsersetExpression]) {
+    output.push_str(name);
+    output.push('(');
+    let mut separator = "";
+    for expression in expressions {
+        output.push_str(separator);
+        push_expression(output, expression);
+        separator = ", ";
+    }
+    output.push(')');
+}
+
+fn is_parent_component(component: std::path::Component<'_>) -> bool {
+    matches!(component, std::path::Component::ParentDir)
+}
+
+const fn policy_import_batch_size() -> usize {
+    10_000
+}

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -185,10 +185,11 @@ pub(crate) fn write_policy_files(
 }
 
 pub(crate) fn apply_policy_text_to_service(
-    service: &mut crate::ZanzibarService,
+    service: &mut crate::WriterState,
     policy: &PolicyText,
 ) -> Result<crate::revision::ConsistencyToken, ZanzibarError> {
-    let mut candidate = crate::ZanzibarService::with_snapshot_retention(service.retained_snapshots)
+    let published_state = service.published_state.clone();
+    let mut candidate = crate::WriterState::with_snapshot_retention(service.retained_snapshots)
         .with_evaluation_limits(service.evaluation_limits);
     candidate.datastore_id = service.datastore_id;
     candidate.last_revision = service.last_revision;
@@ -205,6 +206,7 @@ pub(crate) fn apply_policy_text_to_service(
     if !mutations.is_empty() {
         token = candidate.apply_relationship_mutations(mutations, [])?;
     }
+    candidate.replace_publisher(published_state);
     *service = candidate;
     Ok(token)
 }
@@ -214,7 +216,7 @@ pub(crate) fn save_snapshot_from_policy_text(
     policy: &PolicyText,
     options: SnapshotSaveOptions,
 ) -> Result<(), PolicyIoError> {
-    let service = crate::ZanzibarService::from_policy_text(policy)?;
+    let service = crate::WriterState::from_policy_text(policy)?;
     service.save_snapshot(path, options)?;
     Ok(())
 }

--- a/src/relationship.rs
+++ b/src/relationship.rs
@@ -324,6 +324,36 @@ pub enum RelationshipMutation {
 }
 
 impl RelationshipMutation {
+    /// Creates an insert-if-absent mutation from relationship text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when `relationship` is not a valid `object#relation@subject`
+    /// relationship.
+    pub fn create(relationship: impl AsRef<str>) -> Result<Self, DomainError> {
+        Ok(Self::Create(relationship.as_ref().parse()?))
+    }
+
+    /// Creates an idempotent insert mutation from relationship text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when `relationship` is not a valid `object#relation@subject`
+    /// relationship.
+    pub fn touch(relationship: impl AsRef<str>) -> Result<Self, DomainError> {
+        Ok(Self::Touch(relationship.as_ref().parse()?))
+    }
+
+    /// Creates a remove-only-if-present mutation from relationship text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when `relationship` is not a valid `object#relation@subject`
+    /// relationship.
+    pub fn delete(relationship: impl AsRef<str>) -> Result<Self, DomainError> {
+        Ok(Self::Delete(relationship.as_ref().parse()?))
+    }
+
     /// Returns the relationship targeted by this mutation.
     #[must_use]
     pub fn relationship(&self) -> &Relationship {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,98 @@
+//! Runtime snapshot state shared by public engine reads and writer publication.
+
+use std::{collections::VecDeque, sync::Arc};
+
+use arc_swap::ArcSwapOption;
+
+use crate::{
+    error::ZanzibarError,
+    eval::EvaluationLimits,
+    revision::{
+        Consistency, ConsistencyError, ConsistencyToken, DatastoreId, PublishedSnapshot, Revision,
+    },
+};
+
+pub(crate) type SharedEngineState = Arc<ArcSwapOption<EngineState>>;
+
+#[derive(Debug)]
+pub(crate) struct EngineState {
+    latest_snapshot: Arc<PublishedSnapshot>,
+    snapshot_history: VecDeque<Arc<PublishedSnapshot>>,
+    datastore_id: DatastoreId,
+    last_revision: Revision,
+    evaluation_limits: EvaluationLimits,
+}
+
+impl EngineState {
+    pub(crate) fn new(
+        latest_snapshot: Arc<PublishedSnapshot>,
+        snapshot_history: VecDeque<Arc<PublishedSnapshot>>,
+        datastore_id: DatastoreId,
+        last_revision: Revision,
+        evaluation_limits: EvaluationLimits,
+    ) -> Self {
+        Self {
+            latest_snapshot,
+            snapshot_history,
+            datastore_id,
+            last_revision,
+            evaluation_limits,
+        }
+    }
+
+    pub(crate) fn latest_snapshot(&self) -> Arc<PublishedSnapshot> {
+        Arc::clone(&self.latest_snapshot)
+    }
+
+    pub(crate) const fn evaluation_limits(&self) -> EvaluationLimits {
+        self.evaluation_limits
+    }
+
+    pub(crate) fn snapshot_for_consistency(
+        &self,
+        consistency: Consistency,
+    ) -> Result<Arc<PublishedSnapshot>, ZanzibarError> {
+        match consistency {
+            Consistency::Latest => Ok(Arc::clone(&self.latest_snapshot)),
+            Consistency::Exact(token) => self.snapshot_for_token(&token),
+        }
+    }
+
+    fn snapshot_for_token(
+        &self,
+        token: &ConsistencyToken,
+    ) -> Result<Arc<PublishedSnapshot>, ZanzibarError> {
+        if token.datastore_id() != self.datastore_id {
+            return Err(ConsistencyError::WrongDatastore.into());
+        }
+        if token.revision() > self.last_revision {
+            return Err(ConsistencyError::RevisionUnavailable {
+                revision: token.revision(),
+            }
+            .into());
+        }
+        if let Some(oldest) = self.snapshot_history.front()
+            && token.revision() < oldest.revision()
+        {
+            return Err(ConsistencyError::RevisionExpired {
+                revision: token.revision(),
+            }
+            .into());
+        }
+        let snapshot = self
+            .snapshot_history
+            .iter()
+            .find(|snapshot| snapshot.revision() == token.revision())
+            .cloned()
+            .ok_or(ConsistencyError::RevisionUnavailable {
+                revision: token.revision(),
+            })?;
+        if snapshot.schema_hash() != token.schema_hash() {
+            return Err(ConsistencyError::SchemaHashMismatch {
+                revision: token.revision(),
+            }
+            .into());
+        }
+        Ok(snapshot)
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt::{self, Write},
     fs::{self, File},
     io::{self, Read},
     num::{NonZeroU64, NonZeroUsize},
@@ -19,7 +18,8 @@ use thiserror::Error;
 use crate::{
     domain::DomainError,
     error::ZanzibarError,
-    model::{NamespaceConfig, RelationConfig, UsersetExpression},
+    model::NamespaceConfig,
+    policy,
     relationship::{IndexedRelationshipStore, StoreError},
     revision::{Revision, SchemaHash},
     schema::{self, CompiledSchema},
@@ -35,12 +35,15 @@ const REQUIRED_SECTION_COUNT: usize = 11;
 const REQUIRED_SECTION_COUNT_U32: u32 = 11;
 const MAX_SCHEMA_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_MAX_FILE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const DEFAULT_ZSTD_LEVEL: i32 = 3;
 
 /// Options used when saving a compact snapshot artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SnapshotSaveOptions {
-    /// Snapshot compression mode. Version 2 supports only uncompressed snapshots.
+    /// Snapshot compression mode.
     pub compression: SnapshotCompression,
+    /// Zstd compression level used when `compression` is [`SnapshotCompression::Zstd`].
+    pub zstd_level: i32,
     /// Whether serialized lookup indexes are included.
     ///
     /// Version 2 requires indexes because fast loading depends on stable sorted index arrays.
@@ -51,6 +54,7 @@ impl Default for SnapshotSaveOptions {
     fn default() -> Self {
         Self {
             compression: SnapshotCompression::None,
+            zstd_level: DEFAULT_ZSTD_LEVEL,
             include_indexes: true,
         }
     }
@@ -61,11 +65,15 @@ impl Default for SnapshotSaveOptions {
 pub enum SnapshotCompression {
     /// Store all sections uncompressed.
     None,
+    /// Wrap the raw `.szsnap` v2 payload in a single zstd frame.
+    Zstd,
 }
 
 /// Options used when loading a compact snapshot artifact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SnapshotLoadOptions {
+    /// Snapshot compression mode expected for the file.
+    pub compression: SnapshotCompression,
     /// Runtime index profile to construct from serialized sorted arrays.
     pub profile: SnapshotLoadProfile,
     /// Validation mode to apply while loading the artifact.
@@ -79,6 +87,7 @@ pub struct SnapshotLoadOptions {
 impl Default for SnapshotLoadOptions {
     fn default() -> Self {
         Self {
+            compression: SnapshotCompression::None,
             profile: SnapshotLoadProfile::FastLoad,
             validation: SnapshotValidationMode::Full,
             integrity: SnapshotIntegrityMode::Checksum,
@@ -429,9 +438,10 @@ pub(crate) fn save_snapshot_file(
             option: "include_indexes=false",
         });
     }
+    validate_compression_options(options)?;
 
     let mut writer = SnapshotSectionWriter::default();
-    let schema_source = canonical_schema_source(snapshot.configs())?;
+    let schema_source = policy::canonical_schema_source(snapshot.configs());
     if schema_source.len() > MAX_SCHEMA_BYTES {
         return Err(SnapshotIoError::LimitExceeded {
             component: "schema section",
@@ -442,7 +452,7 @@ pub(crate) fn save_snapshot_file(
         .relationships()
         .encode_snapshot_sections(&mut writer)?;
     let bytes = encode_file(snapshot, writer)?;
-    fs::write(path, bytes)?;
+    fs::write(path, encode_payload(bytes, options)?)?;
     Ok(())
 }
 
@@ -465,6 +475,7 @@ pub(crate) fn load_snapshot_file(
         });
     }
     let bytes = read_capped_file(path, options.max_file_bytes)?;
+    let bytes = decode_payload(bytes, options)?;
     let reader = SnapshotReader::parse(&bytes, options.integrity)?;
     let schema_section = reader.section(SectionKind::Schema)?;
     if schema_section.bytes().len() > MAX_SCHEMA_BYTES {
@@ -502,6 +513,61 @@ pub(crate) fn load_snapshot_file(
         revision: reader.header().created_revision,
         schema_hash,
     })
+}
+
+fn validate_compression_options(options: SnapshotSaveOptions) -> Result<(), SnapshotIoError> {
+    if options.compression == SnapshotCompression::Zstd
+        && !zstd::compression_level_range().contains(&options.zstd_level)
+    {
+        return Err(SnapshotIoError::UnsupportedOption {
+            option: "zstd_level",
+        });
+    }
+    Ok(())
+}
+
+fn encode_payload(
+    bytes: Vec<u8>,
+    options: SnapshotSaveOptions,
+) -> Result<Vec<u8>, SnapshotIoError> {
+    match options.compression {
+        SnapshotCompression::None => Ok(bytes),
+        SnapshotCompression::Zstd => {
+            zstd::stream::encode_all(bytes.as_slice(), options.zstd_level).map_err(Into::into)
+        }
+    }
+}
+
+fn decode_payload(
+    bytes: Vec<u8>,
+    options: SnapshotLoadOptions,
+) -> Result<Vec<u8>, SnapshotIoError> {
+    match options.compression {
+        SnapshotCompression::None => Ok(bytes),
+        SnapshotCompression::Zstd => decode_zstd_bounded(&bytes, options.max_file_bytes),
+    }
+}
+
+fn decode_zstd_bounded(
+    bytes: &[u8],
+    max_file_bytes: NonZeroU64,
+) -> Result<Vec<u8>, SnapshotIoError> {
+    let read_limit = max_file_bytes
+        .get()
+        .checked_add(1)
+        .ok_or(SnapshotIoError::LimitExceeded {
+            component: "decompressed snapshot file",
+        })?;
+    let decoder = zstd::stream::read::Decoder::new(bytes)?;
+    let mut limited_decoder = decoder.take(read_limit);
+    let mut output = Vec::new();
+    limited_decoder.read_to_end(&mut output)?;
+    if checked_u64_from_usize(output.len())? > max_file_bytes.get() {
+        return Err(SnapshotIoError::LimitExceeded {
+            component: "decompressed snapshot file",
+        });
+    }
+    Ok(output)
 }
 
 fn read_capped_file(path: &Path, max_file_bytes: NonZeroU64) -> Result<Vec<u8>, SnapshotIoError> {
@@ -785,95 +851,6 @@ fn validate_footer(
         });
     }
     Ok(())
-}
-
-fn canonical_schema_source(
-    configs: &HashMap<String, NamespaceConfig>,
-) -> Result<String, SnapshotIoError> {
-    let mut output = String::new();
-    let mut namespaces = configs.values().collect::<Vec<_>>();
-    namespaces.sort_by(|left, right| left.name.cmp(&right.name));
-    for namespace in namespaces {
-        writeln!(&mut output, "namespace {} {{", namespace.name).map_err(format_error)?;
-        let mut relations = namespace.relations.values().collect::<Vec<_>>();
-        relations.sort_by(|left, right| left.name.0.cmp(&right.name.0));
-        for relation in relations {
-            write_relation(&mut output, relation)?;
-        }
-        writeln!(&mut output, "}}\n").map_err(format_error)?;
-    }
-    Ok(output)
-}
-
-fn write_relation(output: &mut String, relation: &RelationConfig) -> Result<(), SnapshotIoError> {
-    match &relation.userset_rewrite {
-        Some(expression) => {
-            writeln!(output, "    relation {} {{", relation.name.0).map_err(format_error)?;
-            write!(output, "        rewrite ").map_err(format_error)?;
-            write_expression(output, expression)?;
-            writeln!(output).map_err(format_error)?;
-            writeln!(output, "    }}").map_err(format_error)?;
-        }
-        None => {
-            writeln!(output, "    relation {} {{}}", relation.name.0).map_err(format_error)?;
-        }
-    }
-    Ok(())
-}
-
-fn write_expression(
-    output: &mut String,
-    expression: &UsersetExpression,
-) -> Result<(), SnapshotIoError> {
-    match expression {
-        UsersetExpression::This => write!(output, "this").map_err(format_error),
-        UsersetExpression::ComputedUserset { relation } => {
-            write!(output, "computed_userset(relation: \"{}\")", relation.0).map_err(format_error)
-        }
-        UsersetExpression::TupleToUserset {
-            tupleset_relation,
-            computed_userset_relation,
-        } => write!(
-            output,
-            "tuple_to_userset(tupleset: \"{}\", computed_userset: \"{}\")",
-            tupleset_relation.0, computed_userset_relation.0,
-        )
-        .map_err(format_error),
-        UsersetExpression::Union(expressions) => {
-            write_expression_list(output, "union", expressions)
-        }
-        UsersetExpression::Intersection(expressions) => {
-            write_expression_list(output, "intersection", expressions)
-        }
-        UsersetExpression::Exclusion { base, exclude } => {
-            write!(output, "exclusion(").map_err(format_error)?;
-            write_expression(output, base)?;
-            write!(output, ", ").map_err(format_error)?;
-            write_expression(output, exclude)?;
-            write!(output, ")").map_err(format_error)
-        }
-    }
-}
-
-fn write_expression_list(
-    output: &mut String,
-    name: &str,
-    expressions: &[UsersetExpression],
-) -> Result<(), SnapshotIoError> {
-    write!(output, "{name}(").map_err(format_error)?;
-    let mut separator = "";
-    for expression in expressions {
-        write!(output, "{separator}").map_err(format_error)?;
-        write_expression(output, expression)?;
-        separator = ", ";
-    }
-    write!(output, ")").map_err(format_error)
-}
-
-fn format_error(_: fmt::Error) -> SnapshotIoError {
-    SnapshotIoError::Format {
-        reason: "schema serialization failed",
-    }
 }
 
 #[derive(Debug)]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -60,6 +60,30 @@ impl Default for SnapshotSaveOptions {
     }
 }
 
+impl SnapshotSaveOptions {
+    /// Creates save options for an uncompressed `.szsnap` artifact.
+    #[must_use]
+    pub fn uncompressed() -> Self {
+        Self::default()
+    }
+
+    /// Creates save options for a zstd-wrapped `.szsnap.zst` artifact.
+    #[must_use]
+    pub fn zstd() -> Self {
+        Self {
+            compression: SnapshotCompression::Zstd,
+            ..Self::default()
+        }
+    }
+
+    /// Returns options with a specific zstd compression level.
+    #[must_use]
+    pub fn with_zstd_level(mut self, zstd_level: i32) -> Self {
+        self.zstd_level = zstd_level;
+        self
+    }
+}
+
 /// Snapshot compression mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SnapshotCompression {
@@ -92,6 +116,23 @@ impl Default for SnapshotLoadOptions {
             validation: SnapshotValidationMode::Full,
             integrity: SnapshotIntegrityMode::Checksum,
             max_file_bytes: non_zero_u64(DEFAULT_MAX_FILE_BYTES),
+        }
+    }
+}
+
+impl SnapshotLoadOptions {
+    /// Creates load options for an uncompressed `.szsnap` artifact.
+    #[must_use]
+    pub fn uncompressed() -> Self {
+        Self::default()
+    }
+
+    /// Creates load options for a zstd-wrapped `.szsnap.zst` artifact.
+    #[must_use]
+    pub fn zstd() -> Self {
+        Self {
+            compression: SnapshotCompression::Zstd,
+            ..Self::default()
         }
     }
 }

--- a/tests/compact_snapshot_tests.rs
+++ b/tests/compact_snapshot_tests.rs
@@ -11,7 +11,6 @@ use proptest::{prelude::*, test_runner::TestCaseError};
 use simple_zanzibar::{
     SnapshotCompression, SnapshotIntegrityMode, SnapshotIoError, SnapshotLoadOptions,
     SnapshotLoadProfile, SnapshotSaveOptions, SnapshotValidationMode, ZanzibarEngine,
-    ZanzibarService,
     eval::EvaluationLimits,
     model::{LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, RelationTuple, User},
     relationship::RelationshipMutation,
@@ -52,7 +51,7 @@ fn test_should_save_and_load_snapshot_with_equivalent_behavior()
             SnapshotValidationMode::TrustedFastLoad,
         ),
     ] {
-        let mut loaded = ZanzibarService::load_snapshot(&path, options)?;
+        let loaded = ZanzibarEngine::load_snapshot(&path, options)?;
         assert_equivalent_behavior(&service, &loaded)?;
 
         let writer_token_result = loaded.check_with_consistency(
@@ -63,7 +62,7 @@ fn test_should_save_and_load_snapshot_with_equivalent_behavior()
         );
         assert!(matches!(
             writer_token_result,
-            Err(simple_zanzibar::error::ZanzibarError::Consistency(_))
+            Err(simple_zanzibar::EngineError::Consistency(_))
         ));
 
         let bob_tuple = simple_zanzibar::model::RelationTuple {
@@ -81,11 +80,11 @@ fn test_should_save_and_load_snapshot_with_equivalent_behavior()
 
         let duplicate: simple_zanzibar::domain::Relationship =
             "doc:direct_doc#viewer@group:eng#member".parse()?;
-        let duplicate_result =
-            loaded.apply_relationship_mutations([RelationshipMutation::Create(duplicate)], []);
+        let duplicate_result = loaded
+            .write_relationships_with_preconditions([RelationshipMutation::Create(duplicate)], []);
         assert!(matches!(
             duplicate_result,
-            Err(simple_zanzibar::error::ZanzibarError::Store(_))
+            Err(simple_zanzibar::EngineError::Store(_))
         ));
     }
 
@@ -132,7 +131,7 @@ fn test_should_save_and_load_zstd_snapshot_through_service_and_engine()
         compression: SnapshotCompression::Zstd,
         ..SnapshotLoadOptions::default()
     };
-    let loaded = ZanzibarService::load_snapshot(&path, options)?;
+    let loaded = ZanzibarEngine::load_snapshot(&path, options)?;
     assert_equivalent_behavior(&service, &loaded)?;
 
     let engine = ZanzibarEngine::load_snapshot(&path, options)?;
@@ -167,7 +166,7 @@ fn test_should_apply_snapshot_size_cap_to_zstd_decompressed_payload()
     let raw_len = fs::metadata(&raw_path)?.len();
     let capped_len = raw_len.checked_sub(1).ok_or("raw snapshot is empty")?;
 
-    let result = ZanzibarService::load_snapshot(
+    let result = ZanzibarEngine::load_snapshot(
         &zstd_path,
         SnapshotLoadOptions {
             compression: SnapshotCompression::Zstd,
@@ -210,8 +209,8 @@ fn test_should_match_tiny_golden_snapshot_fixture() -> Result<(), Box<dyn std::e
     let expected = decode_hex(include_str!("fixtures/snapshots/tiny.szsnap.hex"))?;
     assert_eq!(actual, expected);
 
-    let loaded = ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::default())?;
-    assert!(loaded.check(
+    let loaded = ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::default())?;
+    assert!(loaded.check_relation(
         &doc("readme"),
         &Relation("viewer".to_string()),
         &User::UserId("alice".to_string()),
@@ -285,17 +284,17 @@ fn test_should_support_external_integrity_only_for_trusted_fast_load()
 
     let path = temp_snapshot_path("external_integrity");
     fs::write(&path, bytes)?;
-    let loaded = ZanzibarService::load_snapshot(
+    let loaded = ZanzibarEngine::load_snapshot(
         &path,
         snapshot_external_load_options(SnapshotValidationMode::TrustedFastLoad),
     )?;
-    assert!(loaded.check(
+    assert!(loaded.check_relation(
         &doc("direct_doc"),
         &Relation("can_view".to_string()),
         &User::UserId("alice".to_string()),
     )?);
 
-    let unsupported = ZanzibarService::load_snapshot(
+    let unsupported = ZanzibarEngine::load_snapshot(
         &path,
         snapshot_external_load_options(SnapshotValidationMode::Full),
     );
@@ -314,7 +313,7 @@ fn test_should_reject_trusted_fast_load_with_latency_profile()
     let path = temp_snapshot_path("trusted_latency");
     fs::write(&path, bytes)?;
 
-    let result = ZanzibarService::load_snapshot(
+    let result = ZanzibarEngine::load_snapshot(
         &path,
         snapshot_load_options(
             SnapshotLoadProfile::Latency,
@@ -478,17 +477,17 @@ proptest! {
 }
 
 fn assert_equivalent_behavior(
-    original: &ZanzibarService,
-    loaded: &ZanzibarService,
+    original: &ZanzibarEngine,
+    loaded: &ZanzibarEngine,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let alice = User::UserId("alice".to_string());
     let can_view = Relation("can_view".to_string());
-    assert!(original.check(&doc("direct_doc"), &can_view, &alice)?);
-    assert!(loaded.check(&doc("direct_doc"), &can_view, &alice)?);
-    assert!(original.check(&doc("inherited_doc"), &can_view, &alice)?);
-    assert!(loaded.check(&doc("inherited_doc"), &can_view, &alice)?);
-    assert!(!original.check(&doc("denied_doc"), &can_view, &alice)?);
-    assert!(!loaded.check(&doc("denied_doc"), &can_view, &alice)?);
+    assert!(original.check_relation(&doc("direct_doc"), &can_view, &alice)?);
+    assert!(loaded.check_relation(&doc("direct_doc"), &can_view, &alice)?);
+    assert!(original.check_relation(&doc("inherited_doc"), &can_view, &alice)?);
+    assert!(loaded.check_relation(&doc("inherited_doc"), &can_view, &alice)?);
+    assert!(!original.check_relation(&doc("denied_doc"), &can_view, &alice)?);
+    assert!(!loaded.check_relation(&doc("denied_doc"), &can_view, &alice)?);
 
     for (resource, relation) in [
         ("direct_doc", "viewer"),
@@ -499,8 +498,8 @@ fn assert_equivalent_behavior(
         let object = doc(resource);
         let relation = Relation(relation.to_string());
         assert_eq!(
-            original.expand(&object, &relation)?,
-            loaded.expand(&object, &relation)?,
+            original.expand_relation(&object, &relation)?,
+            loaded.expand_relation(&object, &relation)?,
         );
     }
 
@@ -534,7 +533,7 @@ fn assert_equivalent_behavior(
 fn round_trip_random_direct_relationships(
     pairs: &[(u8, u8)],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
     namespace doc {
@@ -562,7 +561,7 @@ fn round_trip_random_direct_relationships(
             SnapshotValidationMode::TrustedFastLoad,
         ),
     ] {
-        let loaded = ZanzibarService::load_snapshot(&path, options)?;
+        let loaded = ZanzibarEngine::load_snapshot(&path, options)?;
         assert_random_direct_equivalence(&service, &loaded, &unique_pairs)?;
     }
     remove_file(&path);
@@ -570,8 +569,8 @@ fn round_trip_random_direct_relationships(
 }
 
 fn assert_random_direct_equivalence(
-    original: &ZanzibarService,
-    loaded: &ZanzibarService,
+    original: &ZanzibarEngine,
+    loaded: &ZanzibarEngine,
     unique_pairs: &BTreeSet<(u8, u8)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let viewer = Relation("viewer".to_string());
@@ -579,16 +578,16 @@ fn assert_random_direct_equivalence(
         let object = doc(&format!("random_doc_{doc_id}"));
         let user = User::UserId(format!("user_{user_id}"));
         assert_eq!(
-            original.check(&object, &viewer, &user)?,
-            loaded.check(&object, &viewer, &user)?,
+            original.check_relation(&object, &viewer, &user)?,
+            loaded.check_relation(&object, &viewer, &user)?,
         );
     }
 
     for doc_id in 0_u8..16 {
         let object = doc(&format!("random_doc_{doc_id}"));
         assert_eq!(
-            original.expand(&object, &viewer)?,
-            loaded.expand(&object, &viewer)?,
+            original.expand_relation(&object, &viewer)?,
+            loaded.expand_relation(&object, &viewer)?,
         );
     }
 
@@ -607,15 +606,16 @@ fn assert_random_direct_equivalence(
     Ok(())
 }
 
-fn populated_service() -> Result<
-    (ZanzibarService, simple_zanzibar::revision::ConsistencyToken),
-    Box<dyn std::error::Error>,
-> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero_u32(32),
-        max_fanout_per_step: non_zero_u32(10_000),
-        max_lookup_results: non_zero_u32(1_000),
-    });
+fn populated_service()
+-> Result<(ZanzibarEngine, simple_zanzibar::revision::ConsistencyToken), Box<dyn std::error::Error>>
+{
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero_u32(32),
+            max_fanout_per_step: non_zero_u32(10_000),
+            max_lookup_results: non_zero_u32(1_000),
+        })
+        .build();
     let mut token = service.add_dsl_with_token(schema())?;
     for relationship in [
         "group:eng#member@user:alice",
@@ -627,7 +627,8 @@ fn populated_service() -> Result<
         "doc:other_doc#viewer@user:carol",
     ] {
         let parsed = relationship.parse()?;
-        token = service.apply_relationship_mutations([RelationshipMutation::Touch(parsed)], [])?;
+        token = service
+            .write_relationships_with_preconditions([RelationshipMutation::Touch(parsed)], [])?;
     }
     Ok((service, token))
 }
@@ -641,8 +642,8 @@ fn snapshot_bytes() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     Ok(bytes)
 }
 
-fn tiny_service() -> Result<ZanzibarService, Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+fn tiny_service() -> Result<ZanzibarEngine, Box<dyn std::error::Error>> {
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
     namespace doc {
@@ -669,7 +670,7 @@ fn assert_corrupt_rejected_with_options(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = temp_snapshot_path(name);
     fs::write(&path, bytes)?;
-    let result = ZanzibarService::load_snapshot(&path, options);
+    let result = ZanzibarEngine::load_snapshot(&path, options);
     remove_file(&path);
     assert!(matches!(
         result,

--- a/tests/compact_snapshot_tests.rs
+++ b/tests/compact_snapshot_tests.rs
@@ -9,8 +9,9 @@ use std::{
 
 use proptest::{prelude::*, test_runner::TestCaseError};
 use simple_zanzibar::{
-    SnapshotIntegrityMode, SnapshotIoError, SnapshotLoadOptions, SnapshotLoadProfile,
-    SnapshotSaveOptions, SnapshotValidationMode, ZanzibarEngine, ZanzibarService,
+    SnapshotCompression, SnapshotIntegrityMode, SnapshotIoError, SnapshotLoadOptions,
+    SnapshotLoadProfile, SnapshotSaveOptions, SnapshotValidationMode, ZanzibarEngine,
+    ZanzibarService,
     eval::EvaluationLimits,
     model::{LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, RelationTuple, User},
     relationship::RelationshipMutation,
@@ -111,6 +112,73 @@ fn test_should_save_and_load_snapshot_through_public_engine_api()
 
     assert!(allowed);
     remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn test_should_save_and_load_zstd_snapshot_through_service_and_engine()
+-> Result<(), Box<dyn std::error::Error>> {
+    let service = populated_service()?.0;
+    let path = temp_snapshot_path("zstd");
+    service.save_snapshot(
+        &path,
+        SnapshotSaveOptions {
+            compression: SnapshotCompression::Zstd,
+            ..SnapshotSaveOptions::default()
+        },
+    )?;
+
+    let options = SnapshotLoadOptions {
+        compression: SnapshotCompression::Zstd,
+        ..SnapshotLoadOptions::default()
+    };
+    let loaded = ZanzibarService::load_snapshot(&path, options)?;
+    assert_equivalent_behavior(&service, &loaded)?;
+
+    let engine = ZanzibarEngine::load_snapshot(&path, options)?;
+    assert!(
+        engine
+            .check(simple_zanzibar::model::CheckRequest::new(
+                doc("direct_doc"),
+                Relation("can_view".to_string()),
+                User::UserId("alice".to_string()),
+                Consistency::Latest,
+            ))?
+            .allowed
+    );
+    remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn test_should_apply_snapshot_size_cap_to_zstd_decompressed_payload()
+-> Result<(), Box<dyn std::error::Error>> {
+    let service = populated_service()?.0;
+    let raw_path = temp_snapshot_path("zstd_cap_raw");
+    let zstd_path = temp_snapshot_path("zstd_cap_compressed");
+    service.save_snapshot(&raw_path, SnapshotSaveOptions::default())?;
+    service.save_snapshot(
+        &zstd_path,
+        SnapshotSaveOptions {
+            compression: SnapshotCompression::Zstd,
+            ..SnapshotSaveOptions::default()
+        },
+    )?;
+    let raw_len = fs::metadata(&raw_path)?.len();
+    let capped_len = raw_len.checked_sub(1).ok_or("raw snapshot is empty")?;
+
+    let result = ZanzibarService::load_snapshot(
+        &zstd_path,
+        SnapshotLoadOptions {
+            compression: SnapshotCompression::Zstd,
+            max_file_bytes: non_zero_u64(capped_len),
+            ..SnapshotLoadOptions::default()
+        },
+    );
+
+    remove_file(&raw_path);
+    remove_file(&zstd_path);
+    assert!(matches!(result, Err(SnapshotIoError::LimitExceeded { .. })));
     Ok(())
 }
 
@@ -615,6 +683,7 @@ fn snapshot_load_options(
     validation: SnapshotValidationMode,
 ) -> SnapshotLoadOptions {
     SnapshotLoadOptions {
+        compression: SnapshotCompression::None,
         profile,
         validation,
         integrity: SnapshotIntegrityMode::Checksum,
@@ -624,6 +693,7 @@ fn snapshot_load_options(
 
 fn snapshot_external_load_options(validation: SnapshotValidationMode) -> SnapshotLoadOptions {
     SnapshotLoadOptions {
+        compression: SnapshotCompression::None,
         profile: SnapshotLoadProfile::FastLoad,
         validation,
         integrity: SnapshotIntegrityMode::External,

--- a/tests/engine_tests.rs
+++ b/tests/engine_tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use simple_zanzibar::{
-    EngineError, ZanzibarEngine,
+    EngineError, TenantId, ZanzibarEngine, ZanzibarTenantShards,
     domain::Relationship,
     model::{
         CheckRequest, ExpandRequest, ExpandedUserset, LookupResourcesRequest,
@@ -23,6 +23,58 @@ const DOC_SCHEMA: &str = r"
         relation viewer {}
     }
 ";
+
+#[test]
+fn test_should_make_engine_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    assert_send_sync::<ZanzibarEngine>();
+}
+
+#[test]
+fn test_should_isolate_multiple_engine_instances() -> Result<(), Box<dyn std::error::Error>> {
+    let first = ZanzibarEngine::builder().build();
+    let second = ZanzibarEngine::builder().build();
+    first.apply_schema(SchemaSource {
+        name: Some("doc-schema"),
+        text: DOC_SCHEMA,
+    })?;
+    second.apply_schema(SchemaSource {
+        name: Some("doc-schema"),
+        text: DOC_SCHEMA,
+    })?;
+
+    first.touch_relationship("doc:readme#viewer@user:alice")?;
+
+    assert!(first.check_relation(&doc_object(), &viewer(), &User::user_id("alice"))?);
+    assert!(!second.check_relation(&doc_object(), &viewer(), &User::user_id("alice"))?);
+    Ok(())
+}
+
+#[test]
+fn test_should_shard_engines_by_tenant() -> Result<(), Box<dyn std::error::Error>> {
+    let shards = ZanzibarTenantShards::default();
+    let tenant_a = TenantId::new("tenant-a")?;
+    let tenant_b = TenantId::new("tenant-b")?;
+
+    let first_a = shards.get_or_create(tenant_a.clone());
+    let second_a = shards.get_or_create(tenant_a.clone());
+    let engine_b = shards.get_or_create(tenant_b.clone());
+    assert!(Arc::ptr_eq(&first_a, &second_a));
+
+    for engine in [&first_a, &engine_b] {
+        engine.apply_schema(SchemaSource {
+            name: Some("doc-schema"),
+            text: DOC_SCHEMA,
+        })?;
+    }
+    first_a.touch_relationship("doc:readme#viewer@user:alice")?;
+
+    assert!(first_a.check_relation(&doc_object(), &viewer(), &User::user_id("alice"))?);
+    assert!(!engine_b.check_relation(&doc_object(), &viewer(), &User::user_id("alice"))?);
+    assert_eq!(shards.tenants(), vec![tenant_a, tenant_b]);
+    Ok(())
+}
 
 #[test]
 fn test_should_use_public_engine_request_response_api() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/eval_tests.rs
+++ b/tests/eval_tests.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, num::NonZeroU32};
 
 use simple_zanzibar::{
-    ZanzibarService,
+    EngineError, ZanzibarEngine,
     error::ZanzibarError,
     eval::{EvaluationError, EvaluationLimits, Membership},
     model::{
@@ -12,9 +12,9 @@ use simple_zanzibar::{
     },
 };
 
-/// Creates a `ZanzibarService` pre-populated with a common test configuration.
-fn create_test_service() -> Result<ZanzibarService, ZanzibarError> {
-    let mut service = ZanzibarService::new();
+/// Creates a `ZanzibarEngine` pre-populated with a common test configuration.
+fn create_test_service() -> Result<ZanzibarEngine, ZanzibarError> {
+    let service = ZanzibarEngine::builder().build();
 
     let doc_namespace = NamespaceConfig {
         name: "doc".to_string(),
@@ -54,7 +54,7 @@ fn create_test_service() -> Result<ZanzibarService, ZanzibarError> {
             ),
         ]),
     };
-    service.add_config(doc_namespace)?;
+    service.apply_namespace_config(doc_namespace)?;
 
     let folder_namespace = NamespaceConfig {
         name: "folder".to_string(),
@@ -77,14 +77,14 @@ fn create_test_service() -> Result<ZanzibarService, ZanzibarError> {
             ),
         ]),
     };
-    service.add_config(folder_namespace)?;
+    service.apply_namespace_config(folder_namespace)?;
 
     Ok(service)
 }
 
 #[test]
 fn test_check_direct_access() -> Result<(), ZanzibarError> {
-    let mut service = create_test_service()?;
+    let service = create_test_service()?;
     let doc1 = Object {
         namespace: "doc".to_string(),
         id: "1".to_string(),
@@ -98,13 +98,13 @@ fn test_check_direct_access() -> Result<(), ZanzibarError> {
         user: alice.clone(),
     })?;
 
-    assert!(service.check(&doc1, &owner_rel, &alice)?);
+    assert!(service.check_relation(&doc1, &owner_rel, &alice)?);
     Ok(())
 }
 
 #[test]
 fn test_check_computed_userset() -> Result<(), ZanzibarError> {
-    let mut service = create_test_service()?;
+    let service = create_test_service()?;
     let doc1 = Object {
         namespace: "doc".to_string(),
         id: "1".to_string(),
@@ -120,13 +120,13 @@ fn test_check_computed_userset() -> Result<(), ZanzibarError> {
     })?;
 
     // Alice is an owner, so she should also be a viewer via ComputedUserset.
-    assert!(service.check(&doc1, &viewer_rel, &alice)?);
+    assert!(service.check_relation(&doc1, &viewer_rel, &alice)?);
     Ok(())
 }
 
 #[test]
 fn test_check_hierarchical_access() -> Result<(), ZanzibarError> {
-    let mut service = create_test_service()?;
+    let service = create_test_service()?;
 
     let folder_a = Object {
         namespace: "folder".to_string(),
@@ -155,13 +155,13 @@ fn test_check_hierarchical_access() -> Result<(), ZanzibarError> {
     })?;
 
     // Assert that Bob can view Doc 1 due to inheritance.
-    assert!(service.check(&doc1, &viewer_rel, &bob)?);
+    assert!(service.check_relation(&doc1, &viewer_rel, &bob)?);
     Ok(())
 }
 
 #[test]
 fn test_check_cross_namespace_userset_uses_target_namespace_rewrite() -> Result<(), ZanzibarError> {
-    let mut service = create_test_service()?;
+    let service = create_test_service()?;
 
     let folder_a = Object {
         namespace: "folder".to_string(),
@@ -186,19 +186,19 @@ fn test_check_cross_namespace_userset_uses_target_namespace_rewrite() -> Result<
         user: User::Userset(folder_a, viewer_rel.clone()),
     })?;
 
-    assert!(service.check(&doc1, &viewer_rel, &bob)?);
+    assert!(service.check_relation(&doc1, &viewer_rel, &bob)?);
     Ok(())
 }
 
 #[test]
 fn test_should_evaluate_intersection_and_exclusion() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     let owner = Relation("owner".to_string());
     let editor = Relation("editor".to_string());
     let banned = Relation("banned".to_string());
     let owner_editor = Relation("owner_editor".to_string());
     let allowed_owner = Relation("allowed_owner".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([
             plain_relation(owner.clone()),
@@ -246,23 +246,25 @@ fn test_should_evaluate_intersection_and_exclusion() -> Result<(), ZanzibarError
     service.write_tuple(tuple(doc.clone(), owner, bob.clone()))?;
     service.write_tuple(tuple(doc.clone(), banned, bob.clone()))?;
 
-    assert!(service.check(&doc, &owner_editor, &alice)?);
-    assert!(!service.check(&doc, &owner_editor, &bob)?);
-    assert!(service.check(&doc, &allowed_owner, &alice)?);
-    assert!(!service.check(&doc, &allowed_owner, &bob)?);
+    assert!(service.check_relation(&doc, &owner_editor, &alice)?);
+    assert!(!service.check_relation(&doc, &owner_editor, &bob)?);
+    assert!(service.check_relation(&doc, &allowed_owner, &alice)?);
+    assert!(!service.check_relation(&doc, &allowed_owner, &bob)?);
     Ok(())
 }
 
 #[test]
 fn test_should_return_depth_exceeded_distinct_from_denied() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: NonZeroU32::MIN,
-        max_fanout_per_step: non_zero(100),
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: NonZeroU32::MIN,
+            max_fanout_per_step: non_zero(100),
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let parent = Relation("parent".to_string());
     let viewer = Relation("viewer".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([
             plain_relation(parent.clone()),
@@ -282,11 +284,11 @@ fn test_should_return_depth_exceeded_distinct_from_denied() -> Result<(), Zanzib
         id: "1".to_string(),
     };
 
-    let result = service.check(&doc, &viewer, &User::UserId("alice".to_string()));
+    let result = service.check_relation(&doc, &viewer, &User::UserId("alice".to_string()));
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Evaluation(
+        Err(EngineError::Evaluation(
             EvaluationError::DepthExceeded { .. }
         ))
     ));
@@ -295,18 +297,20 @@ fn test_should_return_depth_exceeded_distinct_from_denied() -> Result<(), Zanzib
 
 #[test]
 fn test_should_return_fanout_exceeded() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero(50),
-        max_fanout_per_step: NonZeroU32::MIN,
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(50),
+            max_fanout_per_step: NonZeroU32::MIN,
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let viewer = Relation("viewer".to_string());
     let member = Relation("member".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([plain_relation(viewer.clone())]),
     })?;
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "group".to_string(),
         relations: HashMap::from([plain_relation(member.clone())]),
     })?;
@@ -328,11 +332,11 @@ fn test_should_return_fanout_exceeded() -> Result<(), ZanzibarError> {
         ))?;
     }
 
-    let result = service.check(&doc, &viewer, &User::UserId("alice".to_string()));
+    let result = service.check_relation(&doc, &viewer, &User::UserId("alice".to_string()));
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Evaluation(
+        Err(EngineError::Evaluation(
             EvaluationError::FanoutExceeded { .. }
         ))
     ));
@@ -342,17 +346,30 @@ fn test_should_return_fanout_exceeded() -> Result<(), ZanzibarError> {
 #[test]
 fn test_should_return_fanout_exceeded_after_limit_plus_one_relationships()
 -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero(50),
-        max_fanout_per_step: non_zero(1_000),
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(50),
+            max_fanout_per_step: non_zero(1_000),
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let viewer = Relation("viewer".to_string());
     let member = Relation("member".to_string());
     let doc = Object {
         namespace: "doc".to_string(),
         id: "1".to_string(),
     };
+    service.add_dsl(
+        r"
+        namespace doc {
+            relation viewer {}
+        }
+
+        namespace group {
+            relation member {}
+        }
+        ",
+    )?;
     for index in 0..1_001 {
         service.write_tuple(tuple(
             doc.clone(),
@@ -366,23 +383,12 @@ fn test_should_return_fanout_exceeded_after_limit_plus_one_relationships()
             ),
         ))?;
     }
-    service.add_dsl(
-        r"
-        namespace doc {
-            relation viewer {}
-        }
 
-        namespace group {
-            relation member {}
-        }
-        ",
-    )?;
-
-    let result = service.check(&doc, &viewer, &User::UserId("alice".to_string()));
+    let result = service.check_relation(&doc, &viewer, &User::UserId("alice".to_string()));
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Evaluation(
+        Err(EngineError::Evaluation(
             EvaluationError::FanoutExceeded { .. }
         ))
     ));
@@ -391,11 +397,13 @@ fn test_should_return_fanout_exceeded_after_limit_plus_one_relationships()
 
 #[test]
 fn test_should_not_spend_indirect_fanout_on_direct_grants() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero(50),
-        max_fanout_per_step: NonZeroU32::MIN,
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(50),
+            max_fanout_per_step: NonZeroU32::MIN,
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let viewer = Relation("viewer".to_string());
     let member = Relation("member".to_string());
     let doc = Object {
@@ -431,15 +439,15 @@ fn test_should_not_spend_indirect_fanout_on_direct_grants() -> Result<(), Zanzib
     ))?;
     service.write_tuple(tuple(group, member, User::UserId("alice".to_string())))?;
 
-    assert!(service.check(&doc, &viewer, &User::UserId("alice".to_string()))?);
+    assert!(service.check_relation(&doc, &viewer, &User::UserId("alice".to_string()))?);
     Ok(())
 }
 
 #[test]
 fn test_should_deny_recursion_cycle_without_depth_error() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     let viewer = Relation("viewer".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([(
             viewer.clone(),
@@ -456,20 +464,22 @@ fn test_should_deny_recursion_cycle_without_depth_error() -> Result<(), Zanzibar
         id: "1".to_string(),
     };
 
-    assert!(!service.check(&doc, &viewer, &User::UserId("alice".to_string()))?);
+    assert!(!service.check_relation(&doc, &viewer, &User::UserId("alice".to_string()))?);
     Ok(())
 }
 
 #[test]
 fn test_should_bound_expand_recursion_depth() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: NonZeroU32::MIN,
-        max_fanout_per_step: non_zero(100),
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: NonZeroU32::MIN,
+            max_fanout_per_step: non_zero(100),
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let parent = Relation("parent".to_string());
     let viewer = Relation("viewer".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([
             plain_relation(parent.clone()),
@@ -483,7 +493,7 @@ fn test_should_bound_expand_recursion_depth() -> Result<(), ZanzibarError> {
         ]),
     })?;
 
-    let result = service.expand(
+    let result = service.expand_relation(
         &Object {
             namespace: "doc".to_string(),
             id: "1".to_string(),
@@ -493,7 +503,7 @@ fn test_should_bound_expand_recursion_depth() -> Result<(), ZanzibarError> {
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Evaluation(
+        Err(EngineError::Evaluation(
             EvaluationError::DepthExceeded { .. }
         ))
     ));
@@ -502,13 +512,15 @@ fn test_should_bound_expand_recursion_depth() -> Result<(), ZanzibarError> {
 
 #[test]
 fn test_should_bound_expand_cycle_without_depth_error() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: NonZeroU32::MIN,
-        max_fanout_per_step: non_zero(100),
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: NonZeroU32::MIN,
+            max_fanout_per_step: non_zero(100),
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let viewer = Relation("viewer".to_string());
-    service.add_config(NamespaceConfig {
+    service.apply_namespace_config(NamespaceConfig {
         name: "doc".to_string(),
         relations: HashMap::from([(
             viewer.clone(),
@@ -521,7 +533,7 @@ fn test_should_bound_expand_cycle_without_depth_error() -> Result<(), ZanzibarEr
         )]),
     })?;
 
-    let expanded = service.expand(
+    let expanded = service.expand_relation(
         &Object {
             namespace: "doc".to_string(),
             id: "1".to_string(),
@@ -535,7 +547,7 @@ fn test_should_bound_expand_cycle_without_depth_error() -> Result<(), ZanzibarEr
 
 #[test]
 fn test_should_expand_from_snapshot_path() -> Result<(), ZanzibarError> {
-    let mut service = create_test_service()?;
+    let service = create_test_service()?;
     let doc = Object {
         namespace: "doc".to_string(),
         id: "1".to_string(),
@@ -547,7 +559,7 @@ fn test_should_expand_from_snapshot_path() -> Result<(), ZanzibarError> {
         User::UserId("alice".to_string()),
     ))?;
 
-    let expanded = service.expand(&doc, &owner)?;
+    let expanded = service.expand_relation(&doc, &owner)?;
 
     assert_eq!(
         expanded,
@@ -559,11 +571,13 @@ fn test_should_expand_from_snapshot_path() -> Result<(), ZanzibarError> {
 #[test]
 fn test_should_not_spend_expand_tuple_to_userset_fanout_on_direct_grants()
 -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero(50),
-        max_fanout_per_step: NonZeroU32::MIN,
-        max_lookup_results: non_zero(100),
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(50),
+            max_fanout_per_step: NonZeroU32::MIN,
+            max_lookup_results: non_zero(100),
+        })
+        .build();
     let parent = Relation("parent".to_string());
     let viewer = Relation("viewer".to_string());
     let inherited_viewer = Relation("inherited_viewer".to_string());
@@ -604,7 +618,7 @@ fn test_should_not_spend_expand_tuple_to_userset_fanout_on_direct_grants()
     ))?;
     service.write_tuple(tuple(folder, viewer, User::UserId("alice".to_string())))?;
 
-    let expanded = service.expand(&doc, &inherited_viewer)?;
+    let expanded = service.expand_relation(&doc, &inherited_viewer)?;
 
     assert_eq!(
         expanded,

--- a/tests/eval_tests.rs
+++ b/tests/eval_tests.rs
@@ -254,6 +254,57 @@ fn test_should_evaluate_intersection_and_exclusion() -> Result<(), ZanzibarError
 }
 
 #[test]
+fn test_should_short_circuit_plain_exclusion_before_recursive_base() -> Result<(), ZanzibarError> {
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(2),
+            max_fanout_per_step: non_zero(100),
+            max_lookup_results: non_zero(100),
+        })
+        .build();
+    let parent = Relation("parent".to_string());
+    let banned = Relation("banned".to_string());
+    let can_view = Relation("can_view".to_string());
+    service.apply_namespace_config(NamespaceConfig {
+        name: "doc".to_string(),
+        relations: HashMap::from([
+            plain_relation(parent.clone()),
+            plain_relation(banned.clone()),
+            (
+                can_view.clone(),
+                RelationConfig {
+                    name: can_view.clone(),
+                    userset_rewrite: Some(UsersetExpression::Exclusion {
+                        base: Box::new(UsersetExpression::TupleToUserset {
+                            tupleset_relation: parent.clone(),
+                            computed_userset_relation: can_view.clone(),
+                        }),
+                        exclude: Box::new(UsersetExpression::ComputedUserset {
+                            relation: banned.clone(),
+                        }),
+                    }),
+                },
+            ),
+        ]),
+    })?;
+
+    let doc = Object {
+        namespace: "doc".to_string(),
+        id: "recursive".to_string(),
+    };
+    let bob = User::UserId("bob".to_string());
+    service.write_tuple(tuple(
+        doc.clone(),
+        parent,
+        User::Userset(doc.clone(), can_view.clone()),
+    ))?;
+    service.write_tuple(tuple(doc.clone(), banned, bob.clone()))?;
+
+    assert!(!service.check_relation(&doc, &can_view, &bob)?);
+    Ok(())
+}
+
+#[test]
 fn test_should_return_depth_exceeded_distinct_from_denied() -> Result<(), ZanzibarError> {
     let service = ZanzibarEngine::builder()
         .evaluation_limits(EvaluationLimits {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use simple_zanzibar::{
-    ZanzibarService,
+    ZanzibarEngine,
     domain::{DomainError, Relationship},
     eval::EvaluationLimits,
     model::{LookupResourcesRequest, LookupSubjectsRequest, Object, Relation, RelationTuple, User},
@@ -50,7 +50,7 @@ const DOCUMENT_SYSTEM_DSL: &str = r#"
 
 #[test]
 fn test_document_system_integration() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Parse and load the DSL
     service.add_dsl(DOCUMENT_SYSTEM_DSL)?;
@@ -103,29 +103,29 @@ fn test_document_system_integration() -> Result<(), Box<dyn std::error::Error>> 
     })?;
 
     // Test direct ownership
-    assert!(service.check(&doc1, &owner_rel, &alice)?);
-    assert!(!service.check(&doc1, &owner_rel, &bob)?);
+    assert!(service.check_relation(&doc1, &owner_rel, &alice)?);
+    assert!(!service.check_relation(&doc1, &owner_rel, &bob)?);
 
     // Test viewer permissions (union of direct, owner, and inherited)
-    assert!(service.check(&doc1, &viewer_rel, &alice)?); // owner -> viewer
-    assert!(service.check(&doc1, &viewer_rel, &bob)?); // direct viewer
-    assert!(service.check(&doc1, &viewer_rel, &charlie)?); // editor -> viewer
+    assert!(service.check_relation(&doc1, &viewer_rel, &alice)?); // owner -> viewer
+    assert!(service.check_relation(&doc1, &viewer_rel, &bob)?); // direct viewer
+    assert!(service.check_relation(&doc1, &viewer_rel, &charlie)?); // editor -> viewer
 
     // Test inherited viewer permissions through parent relationship
-    assert!(service.check(&doc2, &viewer_rel, &alice)?); // inherited from doc1 owner
-    assert!(service.check(&doc2, &viewer_rel, &bob)?); // inherited from doc1 viewer
+    assert!(service.check_relation(&doc2, &viewer_rel, &alice)?); // inherited from doc1 owner
+    assert!(service.check_relation(&doc2, &viewer_rel, &bob)?); // inherited from doc1 viewer
 
     // Test editor permissions (intersection of viewer and exclusion of direct editors from owners)
-    assert!(!service.check(&doc1, &editor_rel, &alice)?); // owner, so excluded from editor
-    assert!(!service.check(&doc1, &editor_rel, &bob)?); // not an editor
-    assert!(service.check(&doc1, &editor_rel, &charlie)?); // direct editor and viewer
+    assert!(!service.check_relation(&doc1, &editor_rel, &alice)?); // owner, so excluded from editor
+    assert!(!service.check_relation(&doc1, &editor_rel, &bob)?); // not an editor
+    assert!(service.check_relation(&doc1, &editor_rel, &charlie)?); // direct editor and viewer
 
     Ok(())
 }
 
 #[test]
 fn test_folder_system_integration() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Parse and load the DSL
     service.add_dsl(DOCUMENT_SYSTEM_DSL)?;
@@ -169,19 +169,19 @@ fn test_folder_system_integration() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // Test direct permissions
-    assert!(service.check(&root_folder, &viewer_rel, &alice)?);
-    assert!(!service.check(&root_folder, &viewer_rel, &bob)?);
+    assert!(service.check_relation(&root_folder, &viewer_rel, &alice)?);
+    assert!(!service.check_relation(&root_folder, &viewer_rel, &bob)?);
 
     // Test inherited permissions
-    assert!(service.check(&sub_folder, &inherited_viewer_rel, &alice)?); // inherited from parent
-    assert!(service.check(&sub_folder, &inherited_viewer_rel, &bob)?); // direct permission
+    assert!(service.check_relation(&sub_folder, &inherited_viewer_rel, &alice)?); // inherited from parent
+    assert!(service.check_relation(&sub_folder, &inherited_viewer_rel, &bob)?); // direct permission
 
     Ok(())
 }
 
 #[test]
 fn test_expand_functionality() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Simple DSL for testing expand
     let simple_dsl = r#"
@@ -224,7 +224,7 @@ fn test_expand_functionality() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // Test expand functionality
-    let expanded = service.expand(&obj, &viewer_rel)?;
+    let expanded = service.expand_relation(&obj, &viewer_rel)?;
 
     // The expanded result should show the union structure
     // This is a basic test - in a real system you'd want more detailed assertions
@@ -236,7 +236,7 @@ fn test_expand_functionality() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_error_handling() {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Test with invalid DSL
     let invalid_dsl = r"
@@ -259,12 +259,12 @@ fn test_error_handling() {
     let user = User::UserId("alice".to_string());
 
     // This should fail because namespace doesn't exist
-    assert!(service.check(&unknown_obj, &rel, &user).is_err());
+    assert!(service.check_relation(&unknown_obj, &rel, &user).is_err());
 }
 
 #[test]
 fn test_tuple_management() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     // Simple namespace for testing
     let simple_dsl = r"
@@ -289,27 +289,27 @@ fn test_tuple_management() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // Initially, alice should not have viewer permission
-    assert!(!service.check(&obj, &rel, &user)?);
+    assert!(!service.check_relation(&obj, &rel, &user)?);
 
     // Add the tuple
     service.write_tuple(tuple.clone())?;
 
     // Now alice should have viewer permission
-    assert!(service.check(&obj, &rel, &user)?);
+    assert!(service.check_relation(&obj, &rel, &user)?);
 
     // Remove the tuple
     service.delete_tuple(&tuple)?;
 
     // Alice should no longer have viewer permission
-    assert!(!service.check(&obj, &rel, &user)?);
+    assert!(!service.check_relation(&obj, &rel, &user)?);
 
     Ok(())
 }
 
 #[test]
-fn test_tuple_written_before_schema_should_backfill_indexed_store()
--> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+fn test_tuple_write_should_require_schema_before_mutation() -> Result<(), Box<dyn std::error::Error>>
+{
+    let service = ZanzibarEngine::builder().build();
     let obj = Object {
         namespace: "test".to_string(),
         id: "item".to_string(),
@@ -317,11 +317,16 @@ fn test_tuple_written_before_schema_should_backfill_indexed_store()
     let rel = Relation("viewer".to_string());
     let user = User::UserId("alice".to_string());
 
-    service.write_tuple(RelationTuple {
+    let result = service.write_tuple(RelationTuple {
         object: obj.clone(),
         relation: rel.clone(),
         user: user.clone(),
-    })?;
+    });
+
+    assert!(matches!(
+        result,
+        Err(simple_zanzibar::EngineError::SchemaRequired)
+    ));
 
     service.add_dsl(
         r"
@@ -331,14 +336,19 @@ fn test_tuple_written_before_schema_should_backfill_indexed_store()
     ",
     )?;
 
-    assert!(service.check(&obj, &rel, &user)?);
+    service.write_tuple(RelationTuple {
+        object: obj.clone(),
+        relation: rel.clone(),
+        user: user.clone(),
+    })?;
+    assert!(service.check_relation(&obj, &rel, &user)?);
     Ok(())
 }
 
 #[test]
 fn test_relationship_batch_should_validate_and_apply_atomically()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
         namespace doc {
@@ -349,7 +359,7 @@ fn test_relationship_batch_should_validate_and_apply_atomically()
 
     let alice = relationship("doc:readme#viewer@user:alice")?;
     let bob = relationship("doc:readme#viewer@user:bob")?;
-    service.apply_relationship_mutations(
+    service.write_relationships_with_preconditions(
         [
             RelationshipMutation::Create(alice.clone()),
             RelationshipMutation::Touch(bob.clone()),
@@ -364,13 +374,13 @@ fn test_relationship_batch_should_validate_and_apply_atomically()
         id: "readme".to_string(),
     };
     let relation = Relation("viewer".to_string());
-    assert!(service.check(&object, &relation, &User::UserId("alice".to_string()))?);
-    assert!(service.check(&object, &relation, &User::UserId("bob".to_string()))?);
+    assert!(service.check_relation(&object, &relation, &User::UserId("alice".to_string()))?);
+    assert!(service.check_relation(&object, &relation, &User::UserId("bob".to_string()))?);
 
     let missing = relationship("doc:missing#viewer@user:alice")?;
     assert!(
         service
-            .apply_relationship_mutations(
+            .write_relationships_with_preconditions(
                 [
                     RelationshipMutation::Create(relationship("doc:readme#viewer@user:charlie")?),
                     RelationshipMutation::Delete(missing),
@@ -379,18 +389,18 @@ fn test_relationship_batch_should_validate_and_apply_atomically()
             )
             .is_err()
     );
-    assert!(!service.check(&object, &relation, &User::UserId("charlie".to_string()))?);
+    assert!(!service.check_relation(&object, &relation, &User::UserId("charlie".to_string()))?);
 
     Ok(())
 }
 
 #[test]
 fn test_relationship_batch_should_require_schema() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
 
     assert!(
         service
-            .apply_relationship_mutations(
+            .write_relationships_with_preconditions(
                 [RelationshipMutation::Create(relationship(
                     "doc:readme#viewer@user:alice",
                 )?)],
@@ -405,7 +415,7 @@ fn test_relationship_batch_should_require_schema() -> Result<(), Box<dyn std::er
 #[test]
 fn test_lookup_resources_should_reuse_check_semantics_and_deduplicate()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r#"
         namespace doc {
@@ -453,11 +463,13 @@ fn test_lookup_resources_should_reuse_check_semantics_and_deduplicate()
 
 #[test]
 fn test_lookup_resources_should_enforce_result_limit() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero(50),
-        max_fanout_per_step: non_zero(100),
-        max_lookup_results: std::num::NonZeroU32::MIN,
-    });
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero(50),
+            max_fanout_per_step: non_zero(100),
+            max_lookup_results: std::num::NonZeroU32::MIN,
+        })
+        .build();
     service.add_dsl(
         r"
         namespace doc {
@@ -483,7 +495,7 @@ fn test_lookup_resources_should_enforce_result_limit() -> Result<(), Box<dyn std
 
 #[test]
 fn test_lookup_subjects_should_reuse_check_semantics() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
         namespace doc {
@@ -519,7 +531,7 @@ fn test_lookup_subjects_should_reuse_check_semantics() -> Result<(), Box<dyn std
 
 #[test]
 fn test_lookup_subjects_should_return_userset_subjects() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
         namespace doc {
@@ -554,7 +566,7 @@ fn test_lookup_subjects_should_return_userset_subjects() -> Result<(), Box<dyn s
 #[test]
 fn test_lookup_subjects_should_reject_unknown_subject_namespace()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(
         r"
         namespace doc {
@@ -576,7 +588,7 @@ fn test_lookup_subjects_should_reject_unknown_subject_namespace()
 #[test]
 fn test_lookup_resources_should_honor_exact_consistency() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     let schema_token = service.add_dsl_with_token(
         r"
         namespace doc {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the DSL parser.
 
-use simple_zanzibar::{ZanzibarService, error::ZanzibarError, model::Relation};
+use simple_zanzibar::{ZanzibarEngine, error::ZanzibarError, model::Relation};
 
 const TEST_DSL: &str = r#"
     // Defines a document namespace with hierarchical permissions.
@@ -36,7 +36,7 @@ const TEST_DSL: &str = r#"
 
 #[test]
 fn test_parse_full_dsl() -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(TEST_DSL)?;
 
     // Retrieve the configs to check them. This requires making the field public

--- a/tests/public_api_completeness_tests.rs
+++ b/tests/public_api_completeness_tests.rs
@@ -1,0 +1,399 @@
+use std::{
+    fs,
+    num::NonZeroU32,
+    path::{Path, PathBuf},
+    process,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use simple_zanzibar::{
+    EngineError, PolicyText, SnapshotCompression, SnapshotLoadOptions, SnapshotSaveOptions,
+    ZanzibarEngine, ZanzibarService,
+    domain::Relationship,
+    eval::EvaluationLimits,
+    model::{
+        LookupObjectPermissionsRequest, LookupPermissionsRequest, LookupResourcesRequest, Object,
+        PermissionSubjects, Relation, User,
+    },
+    relationship::RelationshipMutation,
+    revision::Consistency,
+    schema::SchemaSource,
+};
+
+static NEXT_TEST_PATH: AtomicU64 = AtomicU64::new(1);
+
+#[test]
+fn test_should_lookup_subject_permissions_and_object_permission_subjects()
+-> Result<(), Box<dyn std::error::Error>> {
+    let service = populated_service()?;
+    let alice = User::UserId("alice".to_string());
+    let direct_doc = doc("direct_doc");
+
+    let permissions = service.lookup_permissions(&LookupPermissionsRequest {
+        subject: alice.clone(),
+        resource: direct_doc.clone(),
+        consistency: Consistency::Latest,
+    })?;
+
+    assert_eq!(
+        permissions.permissions,
+        vec![relation("can_view"), relation("viewer")],
+    );
+
+    let object_permissions =
+        service.lookup_object_permissions(&LookupObjectPermissionsRequest {
+            resource: direct_doc,
+            subject_type: "user".to_string(),
+            consistency: Consistency::Latest,
+        })?;
+
+    assert_eq!(
+        object_permissions.permissions,
+        vec![
+            PermissionSubjects {
+                permission: relation("can_view"),
+                subjects: vec![alice.clone()],
+            },
+            PermissionSubjects {
+                permission: relation("viewer"),
+                subjects: vec![alice],
+            },
+        ],
+    );
+    Ok(())
+}
+
+#[test]
+fn test_should_expose_permission_lookup_through_engine_api()
+-> Result<(), Box<dyn std::error::Error>> {
+    let policy = populated_service()?.export_policy_text()?;
+    let engine = ZanzibarEngine::from_policy_text(&policy)?;
+
+    let permissions = engine.lookup_permissions(LookupPermissionsRequest {
+        subject: User::UserId("alice".to_string()),
+        resource: doc("inherited_doc"),
+        consistency: Consistency::Latest,
+    })?;
+
+    assert_eq!(
+        permissions.permissions,
+        vec![relation("can_view"), relation("parent")],
+    );
+    Ok(())
+}
+
+#[test]
+fn test_should_export_and_import_reviewable_policy_text() -> Result<(), Box<dyn std::error::Error>>
+{
+    let service = populated_service()?;
+    let policy = service.export_policy_text()?;
+
+    assert!(policy.schema.starts_with("namespace doc {\n"));
+    assert_eq!(
+        policy
+            .relationship_files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "relationships/doc.zedtuples",
+            "relationships/folder.zedtuples",
+            "relationships/group.zedtuples",
+        ],
+    );
+    let doc_relationships = policy
+        .relationship_files
+        .iter()
+        .find(|file| file.path == "relationships/doc.zedtuples")
+        .ok_or("missing doc relationship file")?;
+    assert!(
+        doc_relationships
+            .contents
+            .contains("doc:direct_doc#viewer@group:eng#member\n")
+    );
+
+    let loaded = ZanzibarService::from_policy_text(&policy)?;
+    assert_equivalent_public_queries(&service, &loaded)?;
+    Ok(())
+}
+
+#[test]
+fn test_should_export_policy_files_grouped_for_review() -> Result<(), Box<dyn std::error::Error>> {
+    let service = populated_service()?;
+    let directory = temp_directory("policy_export");
+    service.export_policy_files(&directory)?;
+
+    let schema = fs::read_to_string(directory.join("schema.zed"))?;
+    let doc_relationships =
+        fs::read_to_string(directory.join("relationships").join("doc.zedtuples"))?;
+    let group_relationships =
+        fs::read_to_string(directory.join("relationships").join("group.zedtuples"))?;
+
+    assert!(schema.starts_with("namespace doc {\n"));
+    assert_eq!(
+        doc_relationships.lines().collect::<Vec<_>>(),
+        vec![
+            "doc:denied_doc#banned@user:alice",
+            "doc:denied_doc#viewer@group:eng#member",
+            "doc:direct_doc#viewer@group:eng#member",
+            "doc:inherited_doc#parent@folder:root#inherited_viewer",
+        ],
+    );
+    assert_eq!(group_relationships, "group:eng#member@user:alice\n");
+
+    remove_directory(&directory);
+    Ok(())
+}
+
+#[test]
+fn test_should_save_snapshot_from_policy_text_with_zstd() -> Result<(), Box<dyn std::error::Error>>
+{
+    let policy = populated_service()?.export_policy_text()?;
+    let path = temp_snapshot_path("policy_zstd");
+    ZanzibarService::save_snapshot_from_policy_text(
+        &path,
+        &policy,
+        SnapshotSaveOptions {
+            compression: SnapshotCompression::Zstd,
+            ..SnapshotSaveOptions::default()
+        },
+    )?;
+
+    let loaded = ZanzibarService::load_snapshot(
+        &path,
+        SnapshotLoadOptions {
+            compression: SnapshotCompression::Zstd,
+            ..SnapshotLoadOptions::default()
+        },
+    )?;
+
+    assert!(loaded.check(
+        &doc("direct_doc"),
+        &relation("can_view"),
+        &User::UserId("alice".to_string()),
+    )?);
+    remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn test_should_reject_duplicate_policy_text_relationships_atomically()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut service = populated_service()?;
+    let before = service.export_policy_text()?;
+    let duplicate_policy = PolicyText::from_single_relationship_file(
+        schema().to_string(),
+        "group:eng#member@user:alice\ngroup:eng#member@user:alice\n".to_string(),
+    );
+
+    let result = service.apply_policy_text(&duplicate_policy);
+
+    assert!(result.is_err());
+    assert_eq!(service.export_policy_text()?, before);
+    Ok(())
+}
+
+#[test]
+fn test_should_replace_and_delete_schema_policy_with_atomic_revalidation()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut service = populated_service()?;
+    let before = service.export_policy_text()?;
+
+    let delete_with_live_relationship = service.delete_relation("doc", "viewer");
+    assert!(delete_with_live_relationship.is_err());
+    assert_eq!(service.export_policy_text()?, before);
+
+    let relationship: Relationship = "doc:direct_doc#viewer@group:eng#member".parse()?;
+    service.apply_relationship_mutations([RelationshipMutation::Delete(relationship)], [])?;
+    let still_invalid = service.delete_relation("doc", "viewer");
+    assert!(still_invalid.is_err());
+
+    for relationship in [
+        "doc:denied_doc#viewer@group:eng#member",
+        "doc:denied_doc#banned@user:alice",
+        "doc:inherited_doc#parent@folder:root#inherited_viewer",
+    ] {
+        service.apply_relationship_mutations(
+            [RelationshipMutation::Delete(relationship.parse()?)],
+            [],
+        )?;
+    }
+    service.delete_namespace("doc")?;
+
+    let check = service.check(
+        &doc("direct_doc"),
+        &relation("can_view"),
+        &User::UserId("alice".to_string()),
+    );
+    assert!(check.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_should_expose_schema_replacement_and_policy_export_through_engine()
+-> Result<(), Box<dyn std::error::Error>> {
+    let engine = ZanzibarEngine::builder().build();
+    engine.apply_schema(SchemaSource {
+        name: Some("docs"),
+        text: r"
+        namespace doc {
+            relation viewer {}
+        }
+        ",
+    })?;
+    let relationship: Relationship = "doc:readme#viewer@user:alice".parse()?;
+    engine.write_relationships([RelationshipMutation::Touch(relationship)])?;
+
+    let replacement = engine.replace_schema(SchemaSource {
+        name: Some("broken"),
+        text: r"
+        namespace doc {
+            relation editor {}
+        }
+        ",
+    });
+    assert!(matches!(replacement, Err(EngineError::Schema(_))));
+
+    let exported = engine.export_policy_text()?;
+    assert!(exported.schema.contains("relation viewer {}"));
+
+    let directory = temp_directory("engine_policy_export");
+    engine.export_policy_files(&directory)?;
+    assert!(directory.join("schema.zed").exists());
+    remove_directory(&directory);
+    Ok(())
+}
+
+fn assert_equivalent_public_queries(
+    original: &ZanzibarService,
+    loaded: &ZanzibarService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let alice = User::UserId("alice".to_string());
+    let request = LookupResourcesRequest {
+        subject: alice.clone(),
+        permission: relation("can_view"),
+        resource_type: "doc".to_string(),
+    };
+    assert_eq!(
+        original.lookup_resources(&request)?,
+        loaded.lookup_resources(&request)?
+    );
+    assert_eq!(
+        original.lookup_permissions(&LookupPermissionsRequest {
+            subject: alice,
+            resource: doc("direct_doc"),
+            consistency: Consistency::Latest,
+        })?,
+        loaded.lookup_permissions(&LookupPermissionsRequest {
+            subject: User::UserId("alice".to_string()),
+            resource: doc("direct_doc"),
+            consistency: Consistency::Latest,
+        })?,
+    );
+    assert_eq!(
+        original.check(
+            &doc("inherited_doc"),
+            &relation("can_view"),
+            &User::UserId("alice".to_string()),
+        )?,
+        loaded.check(
+            &doc("inherited_doc"),
+            &relation("can_view"),
+            &User::UserId("alice".to_string()),
+        )?,
+    );
+    Ok(())
+}
+
+fn populated_service() -> Result<ZanzibarService, Box<dyn std::error::Error>> {
+    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
+        max_depth: non_zero_u32(32),
+        max_fanout_per_step: non_zero_u32(10_000),
+        max_lookup_results: non_zero_u32(1_000),
+    });
+    service.add_dsl(schema())?;
+    for relationship in [
+        "group:eng#member@user:alice",
+        "folder:root#viewer@group:eng#member",
+        "doc:inherited_doc#parent@folder:root#inherited_viewer",
+        "doc:direct_doc#viewer@group:eng#member",
+        "doc:denied_doc#viewer@group:eng#member",
+        "doc:denied_doc#banned@user:alice",
+    ] {
+        service.apply_relationship_mutations(
+            [RelationshipMutation::Touch(relationship.parse()?)],
+            [],
+        )?;
+    }
+    Ok(service)
+}
+
+fn schema() -> &'static str {
+    r#"
+    namespace group {
+        relation member {}
+    }
+
+    namespace folder {
+        relation viewer {}
+        relation inherited_viewer {
+            rewrite computed_userset(relation: "viewer")
+        }
+    }
+
+    namespace doc {
+        relation parent {}
+        relation viewer {}
+        relation banned {}
+        relation can_view {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "viewer"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "inherited_viewer")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+    }
+    "#
+}
+
+fn doc(id: &str) -> Object {
+    Object::new("doc", id)
+}
+
+fn relation(name: &str) -> Relation {
+    Relation::new(name)
+}
+
+fn temp_snapshot_path(name: &str) -> PathBuf {
+    temp_directory_name(name).with_extension("szsnap")
+}
+
+fn temp_directory(name: &str) -> PathBuf {
+    temp_directory_name(name)
+}
+
+fn temp_directory_name(name: &str) -> PathBuf {
+    let counter = NEXT_TEST_PATH.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "simple_zanzibar_public_api_{name}_{}_{}",
+        process::id(),
+        counter,
+    ))
+}
+
+fn remove_file(path: &Path) {
+    let _ = fs::remove_file(path);
+}
+
+fn remove_directory(path: &Path) {
+    let _ = fs::remove_dir_all(path);
+}
+
+fn non_zero_u32(value: u32) -> NonZeroU32 {
+    match NonZeroU32::new(value) {
+        Some(value) => value,
+        None => NonZeroU32::MIN,
+    }
+}

--- a/tests/public_api_completeness_tests.rs
+++ b/tests/public_api_completeness_tests.rs
@@ -8,7 +8,6 @@ use std::{
 
 use simple_zanzibar::{
     EngineError, PolicyText, SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
-    ZanzibarService,
     domain::Relationship,
     eval::EvaluationLimits,
     model::{
@@ -175,7 +174,7 @@ fn test_should_export_and_import_reviewable_policy_text() -> Result<(), Box<dyn 
             .contains("doc:direct_doc#viewer@group:eng#member\n")
     );
 
-    let loaded = ZanzibarService::from_policy_text(&policy)?;
+    let loaded = ZanzibarEngine::from_policy_text(&policy)?;
     assert_equivalent_public_queries(&service, &loaded)?;
     Ok(())
 }
@@ -213,11 +212,11 @@ fn test_should_save_snapshot_from_policy_text_with_zstd() -> Result<(), Box<dyn 
 {
     let policy = populated_service()?.export_policy_text()?;
     let path = temp_snapshot_path("policy_zstd");
-    ZanzibarService::save_snapshot_from_policy_text(&path, &policy, SnapshotSaveOptions::zstd())?;
+    ZanzibarEngine::save_snapshot_from_policy_text(&path, &policy, SnapshotSaveOptions::zstd())?;
 
-    let loaded = ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::zstd())?;
+    let loaded = ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::zstd())?;
 
-    assert!(loaded.check(
+    assert!(loaded.check_relation(
         &doc("direct_doc"),
         &relation("can_view"),
         &User::UserId("alice".to_string()),
@@ -229,7 +228,7 @@ fn test_should_save_snapshot_from_policy_text_with_zstd() -> Result<(), Box<dyn 
 #[test]
 fn test_should_reject_duplicate_policy_text_relationships_atomically()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = populated_service()?;
+    let service = populated_service()?;
     let before = service.export_policy_text()?;
     let duplicate_policy = PolicyText::from_single_relationship_file(
         schema().to_string(),
@@ -246,7 +245,7 @@ fn test_should_reject_duplicate_policy_text_relationships_atomically()
 #[test]
 fn test_should_replace_and_delete_schema_policy_with_atomic_revalidation()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = populated_service()?;
+    let service = populated_service()?;
     let before = service.export_policy_text()?;
 
     let delete_with_live_relationship = service.delete_relation("doc", "viewer");
@@ -254,7 +253,8 @@ fn test_should_replace_and_delete_schema_policy_with_atomic_revalidation()
     assert_eq!(service.export_policy_text()?, before);
 
     let relationship: Relationship = "doc:direct_doc#viewer@group:eng#member".parse()?;
-    service.apply_relationship_mutations([RelationshipMutation::Delete(relationship)], [])?;
+    service
+        .write_relationships_with_preconditions([RelationshipMutation::Delete(relationship)], [])?;
     let still_invalid = service.delete_relation("doc", "viewer");
     assert!(still_invalid.is_err());
 
@@ -263,14 +263,14 @@ fn test_should_replace_and_delete_schema_policy_with_atomic_revalidation()
         "doc:denied_doc#banned@user:alice",
         "doc:inherited_doc#parent@folder:root#inherited_viewer",
     ] {
-        service.apply_relationship_mutations(
+        service.write_relationships_with_preconditions(
             [RelationshipMutation::Delete(relationship.parse()?)],
             [],
         )?;
     }
     service.delete_namespace("doc")?;
 
-    let check = service.check(
+    let check = service.check_relation(
         &doc("direct_doc"),
         &relation("can_view"),
         &User::UserId("alice".to_string()),
@@ -315,8 +315,8 @@ fn test_should_expose_schema_replacement_and_policy_export_through_engine()
 }
 
 fn assert_equivalent_public_queries(
-    original: &ZanzibarService,
-    loaded: &ZanzibarService,
+    original: &ZanzibarEngine,
+    loaded: &ZanzibarEngine,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let alice = User::UserId("alice".to_string());
     let request = LookupResourcesRequest {
@@ -341,12 +341,12 @@ fn assert_equivalent_public_queries(
         })?,
     );
     assert_eq!(
-        original.check(
+        original.check_relation(
             &doc("inherited_doc"),
             &relation("can_view"),
             &User::UserId("alice".to_string()),
         )?,
-        loaded.check(
+        loaded.check_relation(
             &doc("inherited_doc"),
             &relation("can_view"),
             &User::UserId("alice".to_string()),
@@ -355,12 +355,14 @@ fn assert_equivalent_public_queries(
     Ok(())
 }
 
-fn populated_service() -> Result<ZanzibarService, Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new().with_evaluation_limits(EvaluationLimits {
-        max_depth: non_zero_u32(32),
-        max_fanout_per_step: non_zero_u32(10_000),
-        max_lookup_results: non_zero_u32(1_000),
-    });
+fn populated_service() -> Result<ZanzibarEngine, Box<dyn std::error::Error>> {
+    let service = ZanzibarEngine::builder()
+        .evaluation_limits(EvaluationLimits {
+            max_depth: non_zero_u32(32),
+            max_fanout_per_step: non_zero_u32(10_000),
+            max_lookup_results: non_zero_u32(1_000),
+        })
+        .build();
     service.add_dsl(schema())?;
     for relationship in [
         "group:eng#member@user:alice",
@@ -370,7 +372,7 @@ fn populated_service() -> Result<ZanzibarService, Box<dyn std::error::Error>> {
         "doc:denied_doc#viewer@group:eng#member",
         "doc:denied_doc#banned@user:alice",
     ] {
-        service.apply_relationship_mutations(
+        service.write_relationships_with_preconditions(
             [RelationshipMutation::Touch(relationship.parse()?)],
             [],
         )?;

--- a/tests/public_api_completeness_tests.rs
+++ b/tests/public_api_completeness_tests.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use simple_zanzibar::{
-    EngineError, PolicyText, SnapshotCompression, SnapshotLoadOptions, SnapshotSaveOptions,
-    ZanzibarEngine, ZanzibarService,
+    EngineError, PolicyText, SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
+    ZanzibarService,
     domain::Relationship,
     eval::EvaluationLimits,
     model::{
-        LookupObjectPermissionsRequest, LookupPermissionsRequest, LookupResourcesRequest, Object,
-        PermissionSubjects, Relation, User,
+        CheckRequest, LookupObjectPermissionsRequest, LookupPermissionsRequest,
+        LookupResourcesRequest, Object, PermissionSubjects, Relation, User,
     },
     relationship::RelationshipMutation,
     revision::Consistency,
@@ -69,16 +69,79 @@ fn test_should_expose_permission_lookup_through_engine_api()
     let policy = populated_service()?.export_policy_text()?;
     let engine = ZanzibarEngine::from_policy_text(&policy)?;
 
-    let permissions = engine.lookup_permissions(LookupPermissionsRequest {
-        subject: User::UserId("alice".to_string()),
-        resource: doc("inherited_doc"),
-        consistency: Consistency::Latest,
-    })?;
+    let permissions = engine.lookup_permissions(LookupPermissionsRequest::new(
+        User::UserId("alice".to_string()),
+        doc("inherited_doc"),
+        Consistency::Latest,
+    ))?;
 
     assert_eq!(
         permissions.permissions,
         vec![relation("can_view"), relation("parent")],
     );
+    Ok(())
+}
+
+#[test]
+fn test_should_offer_checked_ergonomic_engine_helpers() -> Result<(), Box<dyn std::error::Error>> {
+    let engine = ZanzibarEngine::builder().build();
+    engine.apply_schema(SchemaSource {
+        name: Some("docs"),
+        text: r"
+        namespace doc {
+            relation viewer {}
+        }
+        ",
+    })?;
+
+    engine.touch_relationship("doc:readme#viewer@user:alice")?;
+
+    assert!(
+        engine
+            .check(CheckRequest::new(
+                doc("readme"),
+                relation("viewer"),
+                User::UserId("alice".to_string()),
+                Consistency::Latest,
+            ))?
+            .allowed
+    );
+    assert_eq!(
+        engine
+            .lookup_permissions(LookupPermissionsRequest::new(
+                User::UserId("alice".to_string()),
+                doc("readme"),
+                Consistency::Latest,
+            ))?
+            .permissions,
+        vec![relation("viewer")],
+    );
+    assert_eq!(
+        engine
+            .lookup_object_permissions(LookupObjectPermissionsRequest::new(
+                doc("readme"),
+                "user",
+                Consistency::Latest,
+            ))?
+            .permissions,
+        vec![PermissionSubjects {
+            permission: relation("viewer"),
+            subjects: vec![User::UserId("alice".to_string())],
+        }],
+    );
+
+    engine.delete_relationship("doc:readme#viewer@user:alice")?;
+    assert!(
+        !engine
+            .check(CheckRequest::new(
+                doc("readme"),
+                relation("viewer"),
+                User::UserId("alice".to_string()),
+                Consistency::Latest,
+            ))?
+            .allowed
+    );
+
     Ok(())
 }
 
@@ -150,22 +213,9 @@ fn test_should_save_snapshot_from_policy_text_with_zstd() -> Result<(), Box<dyn 
 {
     let policy = populated_service()?.export_policy_text()?;
     let path = temp_snapshot_path("policy_zstd");
-    ZanzibarService::save_snapshot_from_policy_text(
-        &path,
-        &policy,
-        SnapshotSaveOptions {
-            compression: SnapshotCompression::Zstd,
-            ..SnapshotSaveOptions::default()
-        },
-    )?;
+    ZanzibarService::save_snapshot_from_policy_text(&path, &policy, SnapshotSaveOptions::zstd())?;
 
-    let loaded = ZanzibarService::load_snapshot(
-        &path,
-        SnapshotLoadOptions {
-            compression: SnapshotCompression::Zstd,
-            ..SnapshotLoadOptions::default()
-        },
-    )?;
+    let loaded = ZanzibarService::load_snapshot(&path, SnapshotLoadOptions::zstd())?;
 
     assert!(loaded.check(
         &doc("direct_doc"),

--- a/tests/revision_tests.rs
+++ b/tests/revision_tests.rs
@@ -1,8 +1,7 @@
 use std::{num::NonZeroUsize, str::FromStr};
 
 use simple_zanzibar::{
-    ZanzibarService,
-    error::ZanzibarError,
+    EngineError, ZanzibarEngine,
     model::{NamespaceConfig, Object, Relation, RelationConfig, RelationTuple, User},
     revision::{Consistency, ConsistencyError, ConsistencyToken},
 };
@@ -15,7 +14,7 @@ const DOC_SCHEMA: &str = r"
 
 #[test]
 fn test_should_round_trip_consistency_token() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     let token = service.add_dsl_with_token(DOC_SCHEMA)?;
 
     let parsed = ConsistencyToken::from_str(&token.to_string())?;
@@ -30,12 +29,12 @@ fn test_should_hash_schema_independently_of_namespace_order()
     let doc = namespace("doc", "viewer");
     let folder = namespace("folder", "viewer");
 
-    let mut first = ZanzibarService::new();
-    first.add_config(doc.clone())?;
+    let first = ZanzibarEngine::builder().build();
+    first.apply_namespace_config(doc.clone())?;
     let first_token = first.add_config_with_token(folder.clone())?;
 
-    let mut second = ZanzibarService::new();
-    second.add_config(folder)?;
+    let second = ZanzibarEngine::builder().build();
+    second.apply_namespace_config(folder)?;
     let second_token = second.add_config_with_token(doc)?;
 
     assert_eq!(first_token.schema_hash(), second_token.schema_hash());
@@ -45,7 +44,7 @@ fn test_should_hash_schema_independently_of_namespace_order()
 #[test]
 fn test_should_read_exact_snapshot_without_later_writes() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(DOC_SCHEMA)?;
     let object = doc_object();
     let relation = Relation("viewer".to_string());
@@ -74,7 +73,7 @@ fn test_should_read_exact_snapshot_without_later_writes() -> Result<(), Box<dyn 
 #[test]
 fn test_should_read_exact_snapshot_without_later_delete() -> Result<(), Box<dyn std::error::Error>>
 {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(DOC_SCHEMA)?;
     let object = doc_object();
     let relation = Relation("viewer".to_string());
@@ -97,7 +96,7 @@ fn test_should_read_exact_snapshot_without_later_delete() -> Result<(), Box<dyn 
 #[test]
 fn test_should_read_exact_schema_snapshot_without_later_schema()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     let doc_only_token = service.add_dsl_with_token(DOC_SCHEMA)?;
     service.add_dsl(
         r"
@@ -118,7 +117,7 @@ fn test_should_read_exact_schema_snapshot_without_later_schema()
         Consistency::Exact(doc_only_token),
     );
 
-    assert!(matches!(result, Err(ZanzibarError::Schema(_))));
+    assert!(matches!(result, Err(EngineError::Schema(_))));
     assert!(!service.check_with_consistency(
         &folder,
         &Relation("viewer".to_string()),
@@ -130,7 +129,7 @@ fn test_should_read_exact_schema_snapshot_without_later_schema()
 
 #[test]
 fn test_should_reject_wrong_datastore_token() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(DOC_SCHEMA)?;
     let token = service.write_tuple_with_token(&tuple("readme", "alice"))?;
     let wrong_token = ConsistencyToken::from_str(&replace_token_field(
@@ -148,15 +147,16 @@ fn test_should_reject_wrong_datastore_token() -> Result<(), Box<dyn std::error::
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Consistency(ConsistencyError::WrongDatastore))
+        Err(EngineError::Consistency(ConsistencyError::WrongDatastore))
     ));
     Ok(())
 }
 
 #[test]
 fn test_should_reject_expired_revision_token() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service =
-        ZanzibarService::with_snapshot_retention(NonZeroUsize::new(1).ok_or("invalid retention")?);
+    let service = ZanzibarEngine::builder()
+        .retained_snapshots(NonZeroUsize::new(1).ok_or("invalid retention")?)
+        .build();
     let schema_token = service.add_dsl_with_token(DOC_SCHEMA)?;
     service.write_tuple_with_token(&tuple("readme", "alice"))?;
 
@@ -169,7 +169,7 @@ fn test_should_reject_expired_revision_token() -> Result<(), Box<dyn std::error:
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Consistency(
+        Err(EngineError::Consistency(
             ConsistencyError::RevisionExpired { .. }
         ))
     ));
@@ -178,7 +178,7 @@ fn test_should_reject_expired_revision_token() -> Result<(), Box<dyn std::error:
 
 #[test]
 fn test_should_reject_future_revision_token() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(DOC_SCHEMA)?;
     let token = service.write_tuple_with_token(&tuple("readme", "alice"))?;
     let future = ConsistencyToken::new(
@@ -196,7 +196,7 @@ fn test_should_reject_future_revision_token() -> Result<(), Box<dyn std::error::
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Consistency(
+        Err(EngineError::Consistency(
             ConsistencyError::RevisionUnavailable { .. }
         ))
     ));
@@ -205,7 +205,7 @@ fn test_should_reject_future_revision_token() -> Result<(), Box<dyn std::error::
 
 #[test]
 fn test_should_reject_schema_hash_mismatch() -> Result<(), Box<dyn std::error::Error>> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(DOC_SCHEMA)?;
     let token = service.write_tuple_with_token(&tuple("readme", "alice"))?;
     let mismatched = ConsistencyToken::from_str(&replace_token_field(
@@ -223,7 +223,7 @@ fn test_should_reject_schema_hash_mismatch() -> Result<(), Box<dyn std::error::E
 
     assert!(matches!(
         result,
-        Err(ZanzibarError::Consistency(
+        Err(EngineError::Consistency(
             ConsistencyError::SchemaHashMismatch { .. }
         ))
     ));

--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use simple_zanzibar::{
-    ZanzibarService,
+    EngineError, ZanzibarEngine,
     domain::ObjectType,
     error::ZanzibarError,
     schema::{
@@ -232,7 +232,7 @@ fn test_should_reject_tuple_to_userset_target_missing_on_explicit_allowed_subjec
 #[test]
 fn test_should_reject_relationship_with_unknown_userset_subject_relation()
 -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(VALID_SCHEMA)?;
 
     let tuple = simple_zanzibar::model::RelationTuple {
@@ -253,7 +253,7 @@ fn test_should_reject_relationship_with_unknown_userset_subject_relation()
     let error = service.write_tuple(tuple).err();
     assert!(matches!(
         error,
-        Some(ZanzibarError::Schema(SchemaError::RelationNotFound { relation, .. }))
+        Some(EngineError::Schema(SchemaError::RelationNotFound { relation, .. }))
             if relation == "missing"
     ));
 
@@ -283,7 +283,7 @@ fn test_should_reject_empty_union() {
 #[test]
 fn test_service_should_reject_invalid_schema_without_mutating_previous_schema()
 -> Result<(), ZanzibarError> {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service.add_dsl(VALID_SCHEMA)?;
 
     let invalid = r#"
@@ -303,7 +303,7 @@ fn test_service_should_reject_invalid_schema_without_mutating_previous_schema()
     let viewer = simple_zanzibar::model::Relation("viewer".to_string());
     let alice = simple_zanzibar::model::User::UserId("alice".to_string());
 
-    assert!(!service.check(&doc, &viewer, &alice)?);
+    assert!(!service.check_relation(&doc, &viewer, &alice)?);
 
     Ok(())
 }

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -10,7 +10,7 @@
 )]
 
 use simple_zanzibar::{
-    ZanzibarService,
+    ZanzibarEngine,
     model::{ExpandedUserset, Object, Relation, RelationTuple, User},
 };
 
@@ -79,8 +79,8 @@ fn test_snapshot_parse_tuple_to_userset() {
 
 // -- Expand snapshots --
 
-fn setup_expand_service() -> ZanzibarService {
-    let mut service = ZanzibarService::new();
+fn setup_expand_service() -> ZanzibarEngine {
+    let service = ZanzibarEngine::builder().build();
     service
         .add_dsl(
             r#"
@@ -150,7 +150,7 @@ fn setup_expand_service() -> ZanzibarService {
 fn test_snapshot_expand_union_with_hierarchy() {
     let service = setup_expand_service();
     let expanded = service
-        .expand(&Object::new("doc", "readme"), &Relation::new("viewer"))
+        .expand_relation(&Object::new("doc", "readme"), &Relation::new("viewer"))
         .unwrap();
     insta::assert_debug_snapshot!("expand_viewer_union_hierarchy", expanded);
 }
@@ -159,14 +159,14 @@ fn test_snapshot_expand_union_with_hierarchy() {
 fn test_snapshot_expand_direct_relation() {
     let service = setup_expand_service();
     let expanded = service
-        .expand(&Object::new("doc", "readme"), &Relation::new("owner"))
+        .expand_relation(&Object::new("doc", "readme"), &Relation::new("owner"))
         .unwrap();
     insta::assert_debug_snapshot!("expand_owner_direct", expanded);
 }
 
 #[test]
 fn test_snapshot_expand_exclusion() {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service
         .add_dsl(
             r#"
@@ -203,14 +203,14 @@ fn test_snapshot_expand_exclusion() {
         .unwrap();
 
     let expanded = service
-        .expand(&Object::new("doc", "1"), &Relation::new("viewer"))
+        .expand_relation(&Object::new("doc", "1"), &Relation::new("viewer"))
         .unwrap();
     insta::assert_debug_snapshot!("expand_exclusion_banned", expanded);
 }
 
 #[test]
 fn test_snapshot_expand_intersection() {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service
         .add_dsl(
             r#"
@@ -247,7 +247,7 @@ fn test_snapshot_expand_intersection() {
         .unwrap();
 
     let expanded = service
-        .expand(&Object::new("team", "eng"), &Relation::new("viewer"))
+        .expand_relation(&Object::new("team", "eng"), &Relation::new("viewer"))
         .unwrap();
     insta::assert_debug_snapshot!("expand_intersection", expanded);
 }
@@ -256,9 +256,12 @@ fn test_snapshot_expand_intersection() {
 
 #[test]
 fn test_snapshot_error_namespace_not_found() {
-    let service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
+    service
+        .add_dsl("namespace doc { relation viewer {} }")
+        .unwrap();
     let err = service
-        .check(
+        .check_relation(
             &Object::new("nonexistent", "1"),
             &Relation::new("viewer"),
             &User::user_id("alice"),
@@ -269,13 +272,13 @@ fn test_snapshot_error_namespace_not_found() {
 
 #[test]
 fn test_snapshot_error_relation_not_found() {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service
         .add_dsl("namespace doc { relation owner {} }")
         .unwrap();
 
     let err = service
-        .check(
+        .check_relation(
             &Object::new("doc", "1"),
             &Relation::new("nonexistent"),
             &User::user_id("alice"),
@@ -292,18 +295,16 @@ fn test_snapshot_error_parse_error() {
 
 #[test]
 fn test_snapshot_error_duplicate_tuple() {
-    let mut service = ZanzibarService::new();
+    let service = ZanzibarEngine::builder().build();
     service
         .add_dsl("namespace doc { relation owner {} }")
         .unwrap();
 
-    let tuple = RelationTuple::new(
-        Object::new("doc", "1"),
-        Relation::new("owner"),
-        User::user_id("alice"),
-    );
-    service.write_tuple(tuple.clone()).unwrap();
-    let err = service.write_tuple(tuple).unwrap_err();
+    let mutation =
+        simple_zanzibar::relationship::RelationshipMutation::create("doc:1#owner@user:alice")
+            .unwrap();
+    service.write_relationships([mutation.clone()]).unwrap();
+    let err = service.write_relationships([mutation]).unwrap_err();
     insta::assert_snapshot!("error_duplicate_tuple", err.to_string());
 }
 
@@ -337,7 +338,7 @@ fn collect_users_inner(expanded: &ExpandedUserset, out: &mut Vec<String>) {
 fn test_snapshot_expand_contains_all_users() {
     let service = setup_expand_service();
     let expanded = service
-        .expand(&Object::new("doc", "readme"), &Relation::new("viewer"))
+        .expand_relation(&Object::new("doc", "readme"), &Relation::new("viewer"))
         .unwrap();
 
     let users = collect_users(&expanded);

--- a/tests/snapshots/snapshot_tests__error_namespace_not_found.snap
+++ b/tests/snapshots/snapshot_tests__error_namespace_not_found.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot_tests.rs
 expression: err.to_string()
 ---
-Namespace 'nonexistent' not found
+namespace 'nonexistent' not found


### PR DESCRIPTION
## Summary
- add spec 19 for public API completeness: zstd snapshots, policy text import/export, schema deletion/replacement, and permission-audit queries
- add spec 20 for the concurrent runtime: lock-free snapshot reads, bounded single writer actor, batch writes, and tenant sharding
- remove the legacy mutable public facade and `compat` feature; `ZanzibarEngine` is now the single public runtime facade
- implement zstd snapshot save/load wrappers with bounded decompression
- add policy text import/export, grouped file export, snapshot-from-policy helper, schema replace/delete APIs, and lookup_permissions / lookup_object_permissions
- add ergonomic public API helpers for checked relationship mutations, tuple helpers, request constructors, and zstd snapshot options
- add `TenantId` / `ZanzibarTenantShards` and concurrent read/write tests
- add realistic examples plus `public_api` and `concurrent_runtime` Criterion benchmark harnesses

## Verification
- cargo build --workspace --all-targets
- cargo test --workspace --all-features
- cargo +nightly fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic
- cargo doc --workspace --all-features --no-deps
- cargo audit
- cargo deny check

## Benchmarks
- cargo bench --bench public_api -- --quiet
- cargo bench --bench concurrent_runtime -- --quiet
- cargo bench --bench snapshot snapshot_load_compact/1m -- --sample-size 10
- cargo bench --bench snapshot snapshot_load_trusted_fast/1m -- --sample-size 10
- cargo bench --bench snapshot snapshot_loaded_check_direct/1m -- --sample-size 10
- cargo bench --bench snapshot snapshot_trusted_loaded_check_direct/1m -- --sample-size 10

Detailed benchmark tables are posted as PR comments.