### PR TITLE
phase 14: complete read performance refinement

### DIFF
--- a/benches/perf_optimization.rs
+++ b/benches/perf_optimization.rs
@@ -12,6 +12,8 @@ use std::{
 use criterion::{BatchSize, Criterion};
 #[cfg(feature = "bench-internals")]
 use simple_zanzibar::SnapshotLoadOptions;
+#[cfg(feature = "bench-internals")]
+use simple_zanzibar::relationship::{reset_store_view_read_counters, store_view_read_counters};
 use simple_zanzibar::{
     IndexProfile, SnapshotSaveOptions, ZanzibarEngine,
     domain::Relationship,
@@ -43,6 +45,7 @@ fn main() {
     bench_streaming_lookup(&mut criterion, &filters);
     bench_write_latency(&mut criterion, &filters);
     bench_read_write_mix(&mut criterion, &filters);
+    bench_delta_read_counters(&mut criterion, &filters);
     bench_snapshot_profile_and_timers(&mut criterion, &filters);
     criterion.final_summary();
 }
@@ -181,6 +184,66 @@ fn bench_read_write_mix(criterion: &mut Criterion, filters: &[String]) {
                 started.elapsed()
             });
         });
+    }
+}
+
+fn bench_delta_read_counters(criterion: &mut Criterion, filters: &[String]) {
+    #[cfg(feature = "bench-internals")]
+    {
+        let name = "perf_optimization/read_heavy_delta_counters_1m";
+        if !should_benchmark(name, filters) {
+            return;
+        }
+        let engine = build_engine(RULES_1M);
+        must(
+            engine.write_relationships([
+                must(
+                    RelationshipMutation::delete(
+                        "doc:bulk_doc_000000#viewer@group:target_team#member",
+                    ),
+                    "failed to build counter delete mutation",
+                ),
+                must(
+                    RelationshipMutation::touch("doc:counter_delta#viewer@user:counter_user"),
+                    "failed to build counter touch mutation",
+                ),
+            ]),
+            "failed to prepare delta counter view",
+        );
+        let object = object("doc", "inherited_doc");
+        let relation = relation("can_view");
+        let user = User::user_id(TARGET_USER_ID);
+        reset_store_view_read_counters();
+        for _ in 0..100 {
+            black_box(must(
+                engine.check_relation(&object, &relation, &user),
+                "delta counter check failed",
+            ));
+        }
+        let counters = store_view_read_counters();
+        eprintln!(
+            "{name}: delta_segments_inspected={} tombstone_checks={}",
+            counters.delta_segments_inspected, counters.tombstone_checks,
+        );
+        criterion.bench_function(name, |bencher| {
+            bencher.iter(|| {
+                reset_store_view_read_counters();
+                black_box(must(
+                    engine.check_relation(
+                        black_box(&object),
+                        black_box(&relation),
+                        black_box(&user),
+                    ),
+                    "delta counter check failed",
+                ));
+                black_box(store_view_read_counters())
+            });
+        });
+    }
+    #[cfg(not(feature = "bench-internals"))]
+    {
+        let _ = criterion;
+        let _ = filters;
     }
 }
 

--- a/specs/23-read-performance-optimization-design.md
+++ b/specs/23-read-performance-optimization-design.md
@@ -46,6 +46,21 @@ the mixed-read workload under budget and improved guardrails:
 | `perf_optimization/lookup_resources_streaming_1m` | `[3.0446 ms, 3.1188 ms, 3.1883 ms]` | `[2.6849 ms, 2.7143 ms, 2.7544 ms]` | improved |
 | `perf_optimization/lookup_subjects_streaming_1m` | `[6.2956 us, 6.3200 us, 6.3451 us]` | `[5.4088 us, 5.4472 us, 5.4722 us]` | improved |
 
+M14 completion update on 2026-05-24: schema rewrites now retain same-namespace compiled relation
+ids, plain computed-userset edges use a conservative exact shortcut, lookup verification resets a
+request-local reusable context between candidates, and segmented delta views mask checkpoint
+tombstones with checkpoint-native row identities instead of materializing public relationships.
+
+| Benchmark | First pass | Completion pass | Status |
+| --- | ---: | ---: | --- |
+| `realworld_authorization/1m_rules/mixed_read_workload` | `[52.474 us, 52.895 us, 53.489 us]` | `[41.599 us, 42.085 us, 42.690 us]` | passes <= 55 us |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | `[14.473 us, 14.655 us, 14.833 us]` | `[11.540 us, 11.599 us, 11.646 us]` | passes <= 13.5 us stretch |
+| `perf_optimization/check_prepared_1m` | `[5.2677 us, 5.3115 us, 5.3424 us]` | `[4.3107 us, 4.3867 us, 4.4450 us]` | improved |
+| `perf_optimization/lookup_resources_streaming_1m` | `[2.6849 ms, 2.7143 ms, 2.7544 ms]` | `[2.2853 ms, 2.3241 ms, 2.3551 ms]` | improved |
+| `perf_optimization/lookup_subjects_streaming_1m` | `[5.4088 us, 5.4472 us, 5.4722 us]` | `[4.6735 us, 4.7194 us, 4.7426 us]` | improved |
+| `perf_optimization/read_heavy_heavy_write_batched_1m` | `[10.810 us, 11.567 us, 12.365 us]` | `[10.820 us, 11.773 us, 12.712 us]` | no detected regression |
+| `perf_optimization/read_heavy_delta_counters_1m` | not present | `[4.4792 us, 4.5157 us, 4.5475 us]`; `delta_segments_inspected=1400`, `tombstone_checks=300` over 100 checks | counters recorded |
+
 ## 3. Goals
 
 | # | Goal | Measure |

--- a/specs/25-compiled-computed-userset-shortcut-design.md
+++ b/specs/25-compiled-computed-userset-shortcut-design.md
@@ -1,0 +1,120 @@
+# 25 - Compiled Computed-Userset Shortcut Design
+
+Status: implemented v1
+Owner: Simple Zanzibar
+Last updated: 2026-05-24
+Depends on: [11](./11-schema-system-design.md), [14](./14-evaluation-engine-design.md), [23](./23-read-performance-optimization-design.md), [71](./71-performance-budgets-design.md)
+
+## 1. Purpose
+
+The Phase 14 completion pass made read evaluation ID-native for schema relation edges, but a deep
+follow-up review found one remaining runtime rediscovery in the hot evaluator path:
+`ComputedUserset` expressions still ask the schema resolver whether their target relation has a
+rewrite every time they run. That fact is known during schema compilation.
+
+This spec moves the plain-target proof into the compiled schema IR so `check` can take the exact
+computed-userset shortcut without another resolver lookup. It is intentionally narrower than a
+parser migration: the latest Phase 14 timer records schema parse/compile at about 51 us inside a
+~572 ms full snapshot load, and parsing is not on steady-state read paths.
+
+## 2. Deep Review Findings
+
+| Finding | Decision |
+| --- | --- |
+| `pest` remains a transitive snapshot-load cost, but schema parse/compile is ~0.01% of full 1M snapshot load. | Defer `pest` -> `winnow` until parser work is user-facing or parse benchmarks become material. |
+| `CompiledUsersetExpression::ComputedUserset` stores a relation id but not whether the target relation is plain. | Add a compiled boolean so exact computed-userset shortcuts do not call the resolver. |
+| Exclusion ordering asks `computed_userset_is_plain_relation` at runtime. | Reuse the compiled boolean and remove the helper. |
+| Tuple-to-userset target relation remains name-based because the intermediate object namespace is dynamic. | Keep it unchanged; this spec only handles same-namespace computed-userset edges. |
+
+## 3. Target Flow
+
+```text
+Schema compile
+  |
+  v
++-----------------------------------------+
+| ComputedUserset compiled node           |
+| - relation name for store lookup        |
+| - relation id for recursive schema eval |
+| - target_has_rewrite bool               |
++--------------------+--------------------+
+                     |
+                     v
++-----------------------------------------+
+| Evaluator                               |
+| - if !target_has_rewrite: eval_this     |
+| - else: recurse by relation id          |
+| - exclusion ordering uses same flag     |
++-----------------------------------------+
+```
+
+## 4. Goals
+
+| # | Goal | Measure |
+| --- | --- | --- |
+| G1 | Remove runtime plain-target resolver checks from computed-userset evaluation. | No call to `relation_by_id` just to test `compiled_userset_rewrite().is_none()`. |
+| G2 | Preserve exact Zanzibar semantics. | Existing computed-userset, exclusion, depth, cycle, and cross-namespace tests pass. |
+| G3 | Avoid read-path regression versus Phase 14 completion. | `check_prepared_1m`, inherited check, and mixed read stay within 5% of Phase 14 completion upper estimates. |
+
+## 5. Non-Goals
+
+- No public API or snapshot-format change.
+- No parser migration in this follow-up.
+- No shortcut for tuple-to-userset computed targets whose namespace is determined at runtime.
+- No semantic cache across revisions.
+
+## 6. Design
+
+Extend `CompiledUsersetExpression::ComputedUserset` with `target_has_rewrite: bool`. The schema
+compiler fills it by resolving the same-namespace target relation once, using the uncompiled
+relation definition that already passed schema validation. The evaluator then:
+
+- calls `eval_plain_computed_userset` immediately when `target_has_rewrite` is false;
+- recurses through `check_relation_id` when `target_has_rewrite` is true;
+- uses `!target_has_rewrite` for conservative exclusion ordering.
+
+This preserves the existing relation id for recursive evaluation and keeps the relation name for
+store lookup. It also removes `computed_userset_is_plain_relation`, which reparsed the object
+namespace and repeated a schema hash lookup in a path that already has compiled expression data.
+
+## 7. Benchmarks and Gates
+
+Compare against the Phase 14 completion evidence:
+
+| Benchmark | Phase 14 completion upper | Follow-up gate |
+| --- | ---: | --- |
+| `perf_optimization/check_prepared_1m` | `4.4450 us` | no >5% regression; improvement expected |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | `11.646 us` | no >5% regression; improvement expected |
+| `realworld_authorization/1m_rules/mixed_read_workload` | `42.690 us` | no >5% regression |
+
+Record final numbers in [71](./71-performance-budgets-design.md) and post the comparison to the
+Phase 14 PR.
+
+## 8. AGENTS.md Binding
+
+- Error Handling: compiled invariant failures stay typed as `ZanzibarError`.
+- Type Design: the new flag is crate-private compiled IR, not a public schema API.
+- Safety & Security: no `unsafe`, no unchecked indexing, no panic path from user schema input.
+- Testing: existing adversarial computed-userset and exclusion tests remain mandatory.
+- Performance: no dependency additions; benchmark before claiming the follow-up complete.
+
+## 9. Implementation Evidence
+
+Implemented 2026-05-24 in PR #14 after the Phase 14 completion commit. Benchmarks compare against
+the Phase 14 completion evidence from [71](./71-performance-budgets-design.md).
+
+| Benchmark | Phase 14 completion | Follow-up | Result |
+| --- | ---: | ---: | --- |
+| `perf_optimization/check_prepared_1m` | `[4.3107 us, 4.3867 us, 4.4450 us]` | `[4.2240 us, 4.2590 us, 4.3065 us]` | upper `-3.12%` |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | `[11.540 us, 11.599 us, 11.646 us]` | `[11.211 us, 11.341 us, 11.559 us]` | upper `-0.75%` |
+| `realworld_authorization/1m_rules/mixed_read_workload` | `[41.599 us, 42.085 us, 42.690 us]` | `[40.921 us, 41.317 us, 41.808 us]` | upper `-2.07%` |
+
+Validation:
+
+- `cargo test --workspace --all-targets`
+- `cargo +nightly fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic`
+
+## 10. Cross-References
+
+- <- Depends on: [11-schema-system-design.md](./11-schema-system-design.md), [14-evaluation-engine-design.md](./14-evaluation-engine-design.md), [23-read-performance-optimization-design.md](./23-read-performance-optimization-design.md), [71-performance-budgets-design.md](./71-performance-budgets-design.md)

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -495,6 +495,20 @@ Representative completion-phase timer:
 | `indexes` | `145.074458 ms` |
 | `publish` | `1.834 us` |
 
+## 3.14 Compiled Computed-Userset Shortcut Follow-Up
+
+Measured 2026-05-24 after the deep follow-up review in
+[25](./25-compiled-computed-userset-shortcut-design.md). The parser migration idea was deferred
+because schema parse/compile is ~51 us inside the ~572 ms full snapshot-load path and is absent from
+steady-state reads. The implemented follow-up instead moves computed-userset plain-target knowledge
+into compiled schema IR.
+
+| Benchmark | Phase 14 completion | Follow-up | Result |
+| --- | ---: | ---: | --- |
+| `perf_optimization/check_prepared_1m` | `[4.3107 us, 4.3867 us, 4.4450 us]` | `[4.2240 us, 4.2590 us, 4.3065 us]` | upper `-3.12%`; no regression |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | `[11.540 us, 11.599 us, 11.646 us]` | `[11.211 us, 11.341 us, 11.559 us]` | upper `-0.75%`; no regression |
+| `realworld_authorization/1m_rules/mixed_read_workload` | `[41.599 us, 42.085 us, 42.690 us]` | `[40.921 us, 41.317 us, 41.808 us]` | upper `-2.07%`; no regression |
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.

--- a/specs/71-performance-budgets-design.md
+++ b/specs/71-performance-budgets-design.md
@@ -459,6 +459,42 @@ Representative phase timer:
 | `indexes` | `135.971417 ms` |
 | `publish` | `1.75 us` |
 
+## 3.13 M13 Read-Path Completion Measurements
+
+Measured 2026-05-24 after the remaining read-path refinement work in
+[23](./23-read-performance-optimization-design.md): compiled relation-id schema rewrites,
+conservative exact computed-userset shortcuts, reusable lookup verification contexts, and
+checkpoint-native delta tombstone masking.
+
+| Benchmark | Previous M13 evidence | Completion evidence | Target status |
+| --- | ---: | ---: | --- |
+| `realworld_authorization/1m_rules/mixed_read_workload` | `[52.474 us, 52.895 us, 53.489 us]` | `[41.599 us, 42.085 us, 42.690 us]` | passes <= 55 us |
+| `realworld_authorization/1m_rules/check_doc_inherited_workspace_member` | `[14.473 us, 14.655 us, 14.833 us]` | `[11.540 us, 11.599 us, 11.646 us]` | passes <= 13.5 us stretch |
+| `perf_optimization/check_prepared_1m` | `[5.2677 us, 5.3115 us, 5.3424 us]` | `[4.3107 us, 4.3867 us, 4.4450 us]` | improved |
+| `perf_optimization/lookup_resources_streaming_1m` | `[2.6849 ms, 2.7143 ms, 2.7544 ms]` | `[2.2853 ms, 2.3241 ms, 2.3551 ms]` | improved |
+| `perf_optimization/lookup_subjects_streaming_1m` | `[5.4088 us, 5.4472 us, 5.4722 us]` | `[4.6735 us, 4.7194 us, 4.7426 us]` | improved |
+| `perf_optimization/read_heavy_heavy_write_batched_1m` | `[10.810 us, 11.567 us, 12.365 us]` | `[10.820 us, 11.773 us, 12.712 us]` | no detected regression |
+| `perf_optimization/read_heavy_delta_counters_1m` | not present | `[4.4792 us, 4.5157 us, 4.5475 us]`; `delta_segments_inspected=1400`, `tombstone_checks=300` over 100 checks | counters recorded |
+| `snapshot_file_size/1m` | `77,573,646 bytes` | `77,573,646 bytes` | raw artifact unchanged |
+| `snapshot_file_size_zstd/1m` | `21,512,241 bytes` | `21,512,241 bytes` | zstd artifact unchanged |
+| `snapshot_load_compact/1m` | `[547.67 ms, 550.62 ms, 553.98 ms]` | `[571.24 ms, 572.58 ms, 573.95 ms]` | still under 700 ms; no read-path dependency |
+| `snapshot_load_trusted_fast/1m` | `[171.85 ms, 172.70 ms, 173.52 ms]` | `[174.79 ms, 176.08 ms, 177.49 ms]` | passes <= 200 ms |
+| `snapshot_load_zstd/1m` | `[610.46 ms, 614.59 ms, 618.59 ms]` | `[639.00 ms, 643.41 ms, 650.15 ms]` | distribution-load baseline recorded |
+
+Representative completion-phase timer:
+
+| Phase | Duration |
+| --- | ---: |
+| `file_read` | `7.828875 ms` |
+| `decompression` | `42 ns` |
+| `header_and_sections` | `3.833 us` |
+| `checksum` | `32.892083 ms` |
+| `schema_parse_compile` | `51.083 us` |
+| `symbols` | `87.499833 ms` |
+| `rows` | `292.607208 ms` |
+| `indexes` | `145.074458 ms` |
+| `publish` | `1.834 us` |
+
 ## 4. Design Constraints
 
 - No full relationship-store scans in direct `check`.

--- a/specs/index.md
+++ b/specs/index.md
@@ -30,6 +30,7 @@ Read the v2 specs in numeric order. The order is also the implementation depende
 | [22-snapshot-file-size-optimization-design.md](./22-snapshot-file-size-optimization-design.md) | Design | Snapshot v3 section-size plan for smaller raw/zstd artifacts without weakening safe load semantics. |
 | [23-read-performance-optimization-design.md](./23-read-performance-optimization-design.md) | Design | Next read-path optimization plan for ID-native schema IR, segment-native keys, reusable contexts, and exact-proof shortcuts. |
 | [24-zstd-aware-snapshot-load-design.md](./24-zstd-aware-snapshot-load-design.md) | Design | Zstd-aware snapshot inner layout, row-chunk decode, and low-risk read/load hot-path optimization evidence. |
+| [25-compiled-computed-userset-shortcut-design.md](./25-compiled-computed-userset-shortcut-design.md) | Design | Follow-up read optimization that moves computed-userset plain-target proofs into compiled schema IR. |
 | [60-crates-features-design.md](./60-crates-features-design.md) | Design | Crate layout, feature flags, dependency policy, current crate-version survey. |
 | [70-security-design.md](./70-security-design.md) | Design | Threat model, validation limits, panic policy, unsafe policy, logging/data exposure. |
 | [71-performance-budgets-design.md](./71-performance-budgets-design.md) | Design | Performance targets, benchmark matrix, profiling rules, CI gates. |
@@ -120,6 +121,12 @@ Read the v2 specs in numeric order. The order is also the implementation depende
               | 22 Snapshot File     |                  | 23 Read Performance |  | 24 Zstd-Aware      |
               | Size Optimization    |                  | Optimization        |  | Load                |
               +----------+-----------+                  +----------+-----------+  +----------+-----------+
+                         |                                           |                     |
+                         |                                           v                     |
+                         |                                +----------------------+          |
+                         |                                | 25 Compiled          |          |
+                         |                                | Computed Shortcut    |          |
+                         |                                +----------+-----------+          |
                          |                                           |                     |
                 +--------+---------------------+---------------------+---------------------+--------+
                 |                              |                                                    |

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -477,16 +477,9 @@ impl<'a> EvaluationContext<'a> {
             CompiledUsersetExpression::ComputedUserset {
                 relation,
                 relation_id,
+                target_has_rewrite,
             } => {
-                if self
-                    .snapshot
-                    .schema()
-                    .resolver()
-                    .relation_by_id(*relation_id)
-                    .ok_or_else(compiled_schema_invariant_error)?
-                    .compiled_userset_rewrite()
-                    .is_none()
-                {
+                if !target_has_rewrite {
                     return self.eval_plain_computed_userset(object, relation, user);
                 }
                 self.check_relation_id(object, relation, *relation_id, user)
@@ -659,7 +652,7 @@ impl<'a> EvaluationContext<'a> {
         base: &CompiledUsersetExpression,
         exclude: &CompiledUsersetExpression,
     ) -> Result<Membership, ZanzibarError> {
-        if self.should_eval_exclude_first(object, exclude) {
+        if Self::should_eval_exclude_first(exclude) {
             let exclude_result =
                 self.eval_compiled_schema_expression(object, relation_name, user, exclude)?;
             if exclude_result == Membership::Allowed {
@@ -678,32 +671,17 @@ impl<'a> EvaluationContext<'a> {
         Ok(base.exclusion(exclude))
     }
 
-    fn should_eval_exclude_first(
-        &self,
-        object: &Object,
-        exclude: &CompiledUsersetExpression,
-    ) -> bool {
+    fn should_eval_exclude_first(exclude: &CompiledUsersetExpression) -> bool {
         match exclude {
             CompiledUsersetExpression::This => true,
-            CompiledUsersetExpression::ComputedUserset { relation, .. } => {
-                self.computed_userset_is_plain_relation(object, relation)
-            }
+            CompiledUsersetExpression::ComputedUserset {
+                target_has_rewrite, ..
+            } => !target_has_rewrite,
             CompiledUsersetExpression::TupleToUserset { .. }
             | CompiledUsersetExpression::Union(_)
             | CompiledUsersetExpression::Intersection(_)
             | CompiledUsersetExpression::Exclusion { .. } => false,
         }
-    }
-
-    fn computed_userset_is_plain_relation(&self, object: &Object, relation: &RelationName) -> bool {
-        let Ok(object_type) = ObjectType::try_from(object.namespace.as_str()) else {
-            return false;
-        };
-        self.snapshot
-            .schema()
-            .resolver()
-            .relation(&object_type, relation)
-            .is_ok_and(|definition| definition.userset_rewrite().is_none())
     }
 
     fn expand_compiled_schema_expression(

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,7 +1,7 @@
 //! Core evaluation logic for `check` and `expand` requests.
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     num::{NonZeroU32, NonZeroUsize},
 };
 
@@ -14,20 +14,17 @@ use crate::{
         ExpandedUserset, LookupResources, LookupResourcesRequest, LookupSubjects,
         LookupSubjectsRequest, Object, Relation, User,
     },
-    relationship::{
-        QueryLimit, RelationshipFilter, RelationshipStoreView, StoreCheckKey, StoreViewCompactIter,
-        SubjectFilter,
-    },
+    relationship::{QueryLimit, StoreCheckKey, SubjectFilter},
     revision::PublishedSnapshot,
     schema::{
-        RelationDefinition as SchemaRelationDefinition,
-        UsersetExpression as SchemaUsersetExpression,
+        CompiledUsersetExpression, RelationDefinition as SchemaRelationDefinition, SchemaRelationId,
     },
 };
 
 const DEFAULT_MAX_DEPTH: u32 = 50;
 const DEFAULT_MAX_FANOUT_PER_STEP: u32 = 1_000;
 const DEFAULT_MAX_LOOKUP_RESULTS: u32 = 1_000;
+const ACTIVE_INDEX_THRESHOLD: usize = 8;
 
 /// Errors produced by the shared evaluation engine.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -61,6 +58,16 @@ pub enum EvaluationKey {
 pub enum CheckKey {
     /// Store-native identifier key for relationships already interned in the compact snapshot.
     Store(StoreCheckKey),
+    /// Validated public object/relation-name key used when a segment-native compact key is not
+    /// available, such as checkpoint-plus-delta views.
+    PublicName {
+        /// Object being checked.
+        object: Object,
+        /// Validated relation or permission name being checked.
+        relation: RelationName,
+        /// Subject being checked.
+        user: User,
+    },
     /// Owned public-model fallback when at least one identifier is absent from the snapshot.
     Public {
         /// Object being checked.
@@ -102,9 +109,9 @@ impl CheckKey {
             .relationships()
             .store_check_key_for_relation_name(object, relation_name, user)
             .map_or_else(
-                || Self::Public {
+                || Self::PublicName {
                     object: object.clone(),
-                    relation: legacy_relation(relation_name),
+                    relation: relation_name.clone(),
                     user: user.clone(),
                 },
                 Self::Store,
@@ -116,11 +123,11 @@ impl CheckKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExpandKey {
     object: Object,
-    relation: Relation,
+    relation: RelationName,
 }
 
 impl ExpandKey {
-    fn new(object: &Object, relation: &Relation) -> Self {
+    fn new(object: &Object, relation: &RelationName) -> Self {
         Self {
             object: object.clone(),
             relation: relation.clone(),
@@ -203,9 +210,19 @@ impl Membership {
 pub struct EvaluationContext<'a> {
     snapshot: &'a PublishedSnapshot,
     limits: EvaluationLimits,
+    generation: NonZeroU32,
+    use_active_indexes: bool,
     remaining_depth: u32,
+    active_checks: HashMap<CheckKey, VisitMark>,
+    active_expands: HashMap<ExpandKey, VisitMark>,
     check_stack: Vec<CheckKey>,
     expand_stack: Vec<ExpandKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VisitMark {
+    generation: NonZeroU32,
+    active: bool,
 }
 
 impl<'a> EvaluationContext<'a> {
@@ -215,9 +232,32 @@ impl<'a> EvaluationContext<'a> {
         Self {
             snapshot,
             limits,
+            generation: NonZeroU32::MIN,
+            use_active_indexes: false,
             remaining_depth: limits.max_depth.get(),
+            active_checks: HashMap::new(),
+            active_expands: HashMap::new(),
             check_stack: Vec::new(),
             expand_stack: Vec::new(),
+        }
+    }
+
+    fn reset_for_reuse(&mut self) {
+        self.remaining_depth = self.limits.max_depth.get();
+        self.use_active_indexes = true;
+        self.check_stack.clear();
+        self.expand_stack.clear();
+        if let Some(generation) = self
+            .generation
+            .get()
+            .checked_add(1)
+            .and_then(NonZeroU32::new)
+        {
+            self.generation = generation;
+        } else {
+            self.generation = NonZeroU32::MIN;
+            self.active_checks.clear();
+            self.active_expands.clear();
         }
     }
 
@@ -233,14 +273,14 @@ impl<'a> EvaluationContext<'a> {
         user: &User,
     ) -> Result<Membership, ZanzibarError> {
         let key = CheckKey::new(self.snapshot, object, relation, user);
-        if self.check_stack.contains(&key) {
+        if self.is_check_active(&key) {
             return Ok(Membership::Denied);
         }
         self.enter(EvaluationKey::Check(key.clone()))?;
-        self.check_stack.push(key);
+        self.push_check_key(key);
 
         let result = self.check_entered(object, relation, user);
-        let _ = self.check_stack.pop();
+        self.pop_check_key();
         self.leave();
         result
     }
@@ -253,17 +293,22 @@ impl<'a> EvaluationContext<'a> {
         relation_definition: &SchemaRelationDefinition,
     ) -> Result<Membership, ZanzibarError> {
         let key = CheckKey::new(self.snapshot, object, relation, user);
-        if self.check_stack.contains(&key) {
+        if self.is_check_active(&key) {
             return Ok(Membership::Denied);
         }
         self.enter(EvaluationKey::Check(key.clone()))?;
-        self.check_stack.push(key);
+        self.push_check_key(key);
 
-        let result = match relation_definition.userset_rewrite() {
-            Some(expression) => self.eval_schema_expression(object, relation, user, expression),
-            None => self.eval_this(object, &RelationName::try_from(relation)?, user),
+        let result = match relation_definition.compiled_userset_rewrite() {
+            Some(expression) => self.eval_compiled_schema_expression(
+                object,
+                relation_definition.name(),
+                user,
+                expression,
+            ),
+            None => self.eval_this(object, relation_definition.name(), user),
         };
-        let _ = self.check_stack.pop();
+        self.pop_check_key();
         self.leave();
         result
     }
@@ -275,14 +320,34 @@ impl<'a> EvaluationContext<'a> {
         user: &User,
     ) -> Result<Membership, ZanzibarError> {
         let key = CheckKey::from_relation_name(self.snapshot, object, relation_name, user);
-        if self.check_stack.contains(&key) {
+        if self.is_check_active(&key) {
             return Ok(Membership::Denied);
         }
         self.enter(EvaluationKey::Check(key.clone()))?;
-        self.check_stack.push(key);
+        self.push_check_key(key);
 
         let result = self.check_relation_name_entered(object, relation_name, user);
-        let _ = self.check_stack.pop();
+        self.pop_check_key();
+        self.leave();
+        result
+    }
+
+    fn check_relation_id(
+        &mut self,
+        object: &Object,
+        relation_name: &RelationName,
+        relation_id: SchemaRelationId,
+        user: &User,
+    ) -> Result<Membership, ZanzibarError> {
+        let key = CheckKey::from_relation_name(self.snapshot, object, relation_name, user);
+        if self.is_check_active(&key) {
+            return Ok(Membership::Denied);
+        }
+        self.enter(EvaluationKey::Check(key.clone()))?;
+        self.push_check_key(key);
+
+        let result = self.check_relation_id_entered(object, relation_name, relation_id, user);
+        self.pop_check_key();
         self.leave();
         result
     }
@@ -297,34 +362,44 @@ impl<'a> EvaluationContext<'a> {
         object: &Object,
         relation: &Relation,
     ) -> Result<ExpandedUserset, ZanzibarError> {
-        let key = ExpandKey::new(object, relation);
-        if self.expand_stack.contains(&key) {
+        let relation_name = RelationName::try_from(relation)?;
+        self.expand_relation_name(object, &relation_name)
+    }
+
+    fn expand_relation_name(
+        &mut self,
+        object: &Object,
+        relation_name: &RelationName,
+    ) -> Result<ExpandedUserset, ZanzibarError> {
+        let key = ExpandKey::new(object, relation_name);
+        if self.is_expand_active(&key) {
             return Ok(ExpandedUserset::Union(Vec::new()));
         }
         self.enter(EvaluationKey::Expand(key.clone()))?;
-        self.expand_stack.push(key);
+        self.push_expand_key(key);
 
-        let result = self.expand_entered(object, relation);
-        let _ = self.expand_stack.pop();
+        let result = self.expand_relation_name_entered(object, relation_name);
+        self.pop_expand_key();
         self.leave();
         result
     }
 
-    fn expand_entered(
+    fn expand_relation_name_entered(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
     ) -> Result<ExpandedUserset, ZanzibarError> {
         let object_type = ObjectType::try_from(object.namespace.as_str())?;
-        let relation_name = RelationName::try_from(relation)?;
         let relation_definition = self
             .snapshot
             .schema()
             .resolver()
-            .relation(&object_type, &relation_name)?;
-        match relation_definition.userset_rewrite() {
-            Some(expression) => self.expand_schema_expression(object, relation, expression),
-            None => self.expand_this(object, relation),
+            .relation(&object_type, relation_name)?;
+        match relation_definition.compiled_userset_rewrite() {
+            Some(expression) => {
+                self.expand_compiled_schema_expression(object, relation_name, expression)
+            }
+            None => self.expand_this(object, relation_name),
         }
     }
 
@@ -361,50 +436,110 @@ impl<'a> EvaluationContext<'a> {
             .schema()
             .resolver()
             .relation(object_type, relation_name)?;
-        match relation_definition.userset_rewrite() {
-            Some(expression) => self.eval_schema_expression(
-                object,
-                &legacy_relation(relation_name),
-                user,
-                expression,
-            ),
+        match relation_definition.compiled_userset_rewrite() {
+            Some(expression) => {
+                self.eval_compiled_schema_expression(object, relation_name, user, expression)
+            }
             None => self.eval_this(object, relation_name, user),
         }
     }
 
-    fn eval_schema_expression(
+    fn check_relation_id_entered(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
+        relation_id: SchemaRelationId,
         user: &User,
-        expression: &SchemaUsersetExpression,
+    ) -> Result<Membership, ZanzibarError> {
+        let relation_definition = self
+            .snapshot
+            .schema()
+            .resolver()
+            .relation_by_id(relation_id)
+            .ok_or_else(compiled_schema_invariant_error)?;
+        match relation_definition.compiled_userset_rewrite() {
+            Some(expression) => {
+                self.eval_compiled_schema_expression(object, relation_name, user, expression)
+            }
+            None => self.eval_this(object, relation_name, user),
+        }
+    }
+
+    fn eval_compiled_schema_expression(
+        &mut self,
+        object: &Object,
+        relation_name: &RelationName,
+        user: &User,
+        expression: &CompiledUsersetExpression,
     ) -> Result<Membership, ZanzibarError> {
         match expression {
-            SchemaUsersetExpression::This => {
-                self.eval_this(object, &RelationName::try_from(relation)?, user)
+            CompiledUsersetExpression::This => self.eval_this(object, relation_name, user),
+            CompiledUsersetExpression::ComputedUserset {
+                relation,
+                relation_id,
+            } => {
+                if self
+                    .snapshot
+                    .schema()
+                    .resolver()
+                    .relation_by_id(*relation_id)
+                    .ok_or_else(compiled_schema_invariant_error)?
+                    .compiled_userset_rewrite()
+                    .is_none()
+                {
+                    return self.eval_plain_computed_userset(object, relation, user);
+                }
+                self.check_relation_id(object, relation, *relation_id, user)
             }
-            SchemaUsersetExpression::ComputedUserset { relation } => {
-                self.check_relation_name(object, relation, user)
-            }
-            SchemaUsersetExpression::TupleToUserset {
-                tupleset_relation,
+            CompiledUsersetExpression::TupleToUserset {
+                tupleset_relation: _,
+                tupleset_relation_id,
                 computed_userset_relation,
-            } => self.eval_tuple_to_userset(
-                object,
-                user,
-                tupleset_relation,
-                computed_userset_relation,
-            ),
-            SchemaUsersetExpression::Union(expressions) => {
-                self.eval_schema_union(object, relation, user, expressions)
+            } => {
+                let tupleset_relation = self
+                    .snapshot
+                    .schema()
+                    .resolver()
+                    .relation_by_id(*tupleset_relation_id)
+                    .ok_or_else(compiled_schema_invariant_error)?
+                    .name()
+                    .clone();
+                self.eval_tuple_to_userset(
+                    object,
+                    user,
+                    &tupleset_relation,
+                    computed_userset_relation,
+                )
             }
-            SchemaUsersetExpression::Intersection(expressions) => {
-                self.eval_schema_intersection(object, relation, user, expressions)
+            CompiledUsersetExpression::Union(expressions) => {
+                self.eval_compiled_schema_union(object, relation_name, user, expressions)
             }
-            SchemaUsersetExpression::Exclusion { base, exclude } => {
-                self.eval_schema_exclusion(object, relation, user, base, exclude)
+            CompiledUsersetExpression::Intersection(expressions) => {
+                self.eval_compiled_schema_intersection(object, relation_name, user, expressions)
+            }
+            CompiledUsersetExpression::Exclusion { base, exclude } => {
+                self.eval_compiled_schema_exclusion(object, relation_name, user, base, exclude)
             }
         }
+    }
+
+    fn eval_plain_computed_userset(
+        &mut self,
+        object: &Object,
+        relation_name: &RelationName,
+        user: &User,
+    ) -> Result<Membership, ZanzibarError> {
+        let key = CheckKey::from_relation_name(self.snapshot, object, relation_name, user);
+        if self.is_check_active(&key) {
+            return Ok(Membership::Denied);
+        }
+        self.enter(EvaluationKey::Check(key.clone()))?;
+        self.push_check_key(key);
+
+        let result = self.eval_this(object, relation_name, user);
+        self.pop_check_key();
+        self.leave();
+        result
     }
 
     fn eval_this(
@@ -415,23 +550,20 @@ impl<'a> EvaluationContext<'a> {
     ) -> Result<Membership, ZanzibarError> {
         let resource = DomainObjectRef::try_from(object)?;
         let subject = SubjectFilter::try_from(user)?;
-        let exact_filter =
-            RelationshipFilter::for_exact_subject(&resource, relation_name.clone(), subject);
-        if self
-            .snapshot
-            .relationships()
-            .any_resource_match(&exact_filter)
-        {
+        if self.snapshot.relationships().any_resource_relation_subject(
+            &resource,
+            relation_name,
+            &subject,
+        ) {
             return Ok(Membership::Allowed);
         }
 
         let mut fanout = 0_u32;
-        for relationship in indexed_resource_relation(
-            self.snapshot.relationships(),
-            object,
+        for relationship in self.snapshot.relationships().resource_relation(
+            &resource,
             relation_name,
             unbounded_query_limit(),
-        )? {
+        ) {
             if let Some((nested_object, nested_relation)) =
                 relationship.subject_userset_relation_name()?
             {
@@ -456,12 +588,12 @@ impl<'a> EvaluationContext<'a> {
         computed_userset_relation: &RelationName,
     ) -> Result<Membership, ZanzibarError> {
         let mut fanout = 0_u32;
-        for relationship in indexed_resource_relation(
-            self.snapshot.relationships(),
-            object,
+        let resource = DomainObjectRef::try_from(object)?;
+        for relationship in self.snapshot.relationships().resource_relation(
+            &resource,
             tupleset_relation,
             unbounded_query_limit(),
-        )? {
+        ) {
             if let Some((intermediate_object, _)) = relationship.subject_userset_relation_name()? {
                 self.increment_fanout(&mut fanout)?;
                 if self
@@ -475,16 +607,21 @@ impl<'a> EvaluationContext<'a> {
         Ok(Membership::Denied)
     }
 
-    fn eval_schema_union(
+    fn eval_compiled_schema_union(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
         user: &User,
-        expressions: &[SchemaUsersetExpression],
+        expressions: &[CompiledUsersetExpression],
     ) -> Result<Membership, ZanzibarError> {
         let mut result = Membership::Denied;
         for expression in expressions {
-            result = result.union(self.eval_schema_expression(object, relation, user, expression)?);
+            result = result.union(self.eval_compiled_schema_expression(
+                object,
+                relation_name,
+                user,
+                expression,
+            )?);
             if result == Membership::Allowed {
                 return Ok(result);
             }
@@ -492,17 +629,21 @@ impl<'a> EvaluationContext<'a> {
         Ok(result)
     }
 
-    fn eval_schema_intersection(
+    fn eval_compiled_schema_intersection(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
         user: &User,
-        expressions: &[SchemaUsersetExpression],
+        expressions: &[CompiledUsersetExpression],
     ) -> Result<Membership, ZanzibarError> {
         let mut result = Membership::Allowed;
         for expression in expressions {
-            result = result
-                .intersection(self.eval_schema_expression(object, relation, user, expression)?);
+            result = result.intersection(self.eval_compiled_schema_expression(
+                object,
+                relation_name,
+                user,
+                expression,
+            )?);
             if result == Membership::Denied {
                 return Ok(result);
             }
@@ -510,45 +651,47 @@ impl<'a> EvaluationContext<'a> {
         Ok(result)
     }
 
-    fn eval_schema_exclusion(
+    fn eval_compiled_schema_exclusion(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
         user: &User,
-        base: &SchemaUsersetExpression,
-        exclude: &SchemaUsersetExpression,
+        base: &CompiledUsersetExpression,
+        exclude: &CompiledUsersetExpression,
     ) -> Result<Membership, ZanzibarError> {
         if self.should_eval_exclude_first(object, exclude) {
-            let exclude_result = self.eval_schema_expression(object, relation, user, exclude)?;
+            let exclude_result =
+                self.eval_compiled_schema_expression(object, relation_name, user, exclude)?;
             if exclude_result == Membership::Allowed {
                 return Ok(Membership::Denied);
             }
-            let base_result = self.eval_schema_expression(object, relation, user, base)?;
+            let base_result =
+                self.eval_compiled_schema_expression(object, relation_name, user, base)?;
             return Ok(base_result.exclusion(exclude_result));
         }
 
-        let base = self.eval_schema_expression(object, relation, user, base)?;
+        let base = self.eval_compiled_schema_expression(object, relation_name, user, base)?;
         if base == Membership::Denied {
             return Ok(Membership::Denied);
         }
-        let exclude = self.eval_schema_expression(object, relation, user, exclude)?;
+        let exclude = self.eval_compiled_schema_expression(object, relation_name, user, exclude)?;
         Ok(base.exclusion(exclude))
     }
 
     fn should_eval_exclude_first(
         &self,
         object: &Object,
-        exclude: &SchemaUsersetExpression,
+        exclude: &CompiledUsersetExpression,
     ) -> bool {
         match exclude {
-            SchemaUsersetExpression::This => true,
-            SchemaUsersetExpression::ComputedUserset { relation } => {
+            CompiledUsersetExpression::This => true,
+            CompiledUsersetExpression::ComputedUserset { relation, .. } => {
                 self.computed_userset_is_plain_relation(object, relation)
             }
-            SchemaUsersetExpression::TupleToUserset { .. }
-            | SchemaUsersetExpression::Union(_)
-            | SchemaUsersetExpression::Intersection(_)
-            | SchemaUsersetExpression::Exclusion { .. } => false,
+            CompiledUsersetExpression::TupleToUserset { .. }
+            | CompiledUsersetExpression::Union(_)
+            | CompiledUsersetExpression::Intersection(_)
+            | CompiledUsersetExpression::Exclusion { .. } => false,
         }
     }
 
@@ -563,58 +706,76 @@ impl<'a> EvaluationContext<'a> {
             .is_ok_and(|definition| definition.userset_rewrite().is_none())
     }
 
-    fn expand_schema_expression(
+    fn expand_compiled_schema_expression(
         &mut self,
         object: &Object,
-        relation: &Relation,
-        expression: &SchemaUsersetExpression,
+        relation_name: &RelationName,
+        expression: &CompiledUsersetExpression,
     ) -> Result<ExpandedUserset, ZanzibarError> {
         match expression {
-            SchemaUsersetExpression::This => self.expand_this(object, relation),
-            SchemaUsersetExpression::ComputedUserset { relation } => {
-                self.expand(object, &legacy_relation(relation))
+            CompiledUsersetExpression::This => self.expand_this(object, relation_name),
+            CompiledUsersetExpression::ComputedUserset { relation, .. } => {
+                self.expand_relation_name(object, relation)
             }
-            SchemaUsersetExpression::TupleToUserset {
-                tupleset_relation,
+            CompiledUsersetExpression::TupleToUserset {
+                tupleset_relation: _,
+                tupleset_relation_id,
                 computed_userset_relation,
             } => {
                 let mut users = Vec::new();
                 let mut fanout = 0_u32;
-                for relationship in indexed_resource_relation(
-                    self.snapshot.relationships(),
-                    object,
-                    tupleset_relation,
+                let resource = DomainObjectRef::try_from(object)?;
+                let tupleset_relation = self
+                    .snapshot
+                    .schema()
+                    .resolver()
+                    .relation_by_id(*tupleset_relation_id)
+                    .ok_or_else(compiled_schema_invariant_error)?
+                    .name()
+                    .clone();
+                for relationship in self.snapshot.relationships().resource_relation(
+                    &resource,
+                    &tupleset_relation,
                     unbounded_query_limit(),
-                )? {
+                ) {
                     if let Some((intermediate_object, _)) =
                         relationship.subject_userset_relation_name()?
                     {
                         self.increment_fanout(&mut fanout)?;
-                        users.push(self.expand(
+                        users.push(self.expand_relation_name(
                             &intermediate_object,
-                            &legacy_relation(computed_userset_relation),
+                            computed_userset_relation,
                         )?);
                     }
                 }
                 Ok(ExpandedUserset::Union(users))
             }
-            SchemaUsersetExpression::Union(expressions) => {
+            CompiledUsersetExpression::Union(expressions) => {
                 let mut users = Vec::with_capacity(expressions.len());
                 for expression in expressions {
-                    users.push(self.expand_schema_expression(object, relation, expression)?);
+                    users.push(self.expand_compiled_schema_expression(
+                        object,
+                        relation_name,
+                        expression,
+                    )?);
                 }
                 Ok(ExpandedUserset::Union(users))
             }
-            SchemaUsersetExpression::Intersection(expressions) => {
+            CompiledUsersetExpression::Intersection(expressions) => {
                 let mut users = Vec::with_capacity(expressions.len());
                 for expression in expressions {
-                    users.push(self.expand_schema_expression(object, relation, expression)?);
+                    users.push(self.expand_compiled_schema_expression(
+                        object,
+                        relation_name,
+                        expression,
+                    )?);
                 }
                 Ok(ExpandedUserset::Intersection(users))
             }
-            SchemaUsersetExpression::Exclusion { base, exclude } => {
-                let base = self.expand_schema_expression(object, relation, base)?;
-                let exclude = self.expand_schema_expression(object, relation, exclude)?;
+            CompiledUsersetExpression::Exclusion { base, exclude } => {
+                let base = self.expand_compiled_schema_expression(object, relation_name, base)?;
+                let exclude =
+                    self.expand_compiled_schema_expression(object, relation_name, exclude)?;
                 Ok(ExpandedUserset::Exclusion {
                     base: Box::new(base),
                     exclude: Box::new(exclude),
@@ -626,17 +787,16 @@ impl<'a> EvaluationContext<'a> {
     fn expand_this(
         &mut self,
         object: &Object,
-        relation: &Relation,
+        relation_name: &RelationName,
     ) -> Result<ExpandedUserset, ZanzibarError> {
         let mut users = Vec::new();
         let mut fanout = 0_u32;
-        let relation_name = RelationName::try_from(relation)?;
-        for relationship in indexed_resource_relation(
-            self.snapshot.relationships(),
-            object,
-            &relation_name,
+        let resource = DomainObjectRef::try_from(object)?;
+        for relationship in self.snapshot.relationships().resource_relation(
+            &resource,
+            relation_name,
             self.fanout_query_limit(),
-        )? {
+        ) {
             self.increment_fanout(&mut fanout)?;
             users.push(relationship.expanded_subject()?);
         }
@@ -673,6 +833,108 @@ impl<'a> EvaluationContext<'a> {
             None => NonZeroUsize::MAX,
         };
         QueryLimit::new(limit)
+    }
+
+    fn is_check_active(&self, key: &CheckKey) -> bool {
+        if !self.use_active_indexes || self.check_stack.len() < ACTIVE_INDEX_THRESHOLD {
+            return self.check_stack.contains(key);
+        }
+        self.active_checks
+            .get(key)
+            .is_some_and(|mark| mark.generation == self.generation && mark.active)
+    }
+
+    fn push_check_key(&mut self, key: CheckKey) {
+        if self.use_active_indexes && self.check_stack.len() + 1 >= ACTIVE_INDEX_THRESHOLD {
+            if self.check_stack.len() + 1 == ACTIVE_INDEX_THRESHOLD {
+                self.rebuild_active_checks();
+            }
+            self.active_checks.insert(
+                key.clone(),
+                VisitMark {
+                    generation: self.generation,
+                    active: true,
+                },
+            );
+        }
+        self.check_stack.push(key);
+    }
+
+    fn pop_check_key(&mut self) {
+        if let Some(key) = self.check_stack.pop() {
+            self.deactivate_check_key(&key);
+        }
+    }
+
+    fn deactivate_check_key(&mut self, key: &CheckKey) {
+        if let Some(mark) = self.active_checks.get_mut(key)
+            && mark.generation == self.generation
+        {
+            mark.active = false;
+        }
+    }
+
+    fn rebuild_active_checks(&mut self) {
+        for key in &self.check_stack {
+            self.active_checks.insert(
+                key.clone(),
+                VisitMark {
+                    generation: self.generation,
+                    active: true,
+                },
+            );
+        }
+    }
+
+    fn is_expand_active(&self, key: &ExpandKey) -> bool {
+        if !self.use_active_indexes || self.expand_stack.len() < ACTIVE_INDEX_THRESHOLD {
+            return self.expand_stack.contains(key);
+        }
+        self.active_expands
+            .get(key)
+            .is_some_and(|mark| mark.generation == self.generation && mark.active)
+    }
+
+    fn push_expand_key(&mut self, key: ExpandKey) {
+        if self.use_active_indexes && self.expand_stack.len() + 1 >= ACTIVE_INDEX_THRESHOLD {
+            if self.expand_stack.len() + 1 == ACTIVE_INDEX_THRESHOLD {
+                self.rebuild_active_expands();
+            }
+            self.active_expands.insert(
+                key.clone(),
+                VisitMark {
+                    generation: self.generation,
+                    active: true,
+                },
+            );
+        }
+        self.expand_stack.push(key);
+    }
+
+    fn pop_expand_key(&mut self) {
+        if let Some(key) = self.expand_stack.pop() {
+            self.deactivate_expand_key(&key);
+        }
+    }
+
+    fn deactivate_expand_key(&mut self, key: &ExpandKey) {
+        if let Some(mark) = self.active_expands.get_mut(key)
+            && mark.generation == self.generation
+        {
+            mark.active = false;
+        }
+    }
+
+    fn rebuild_active_expands(&mut self) {
+        for key in &self.expand_stack {
+            self.active_expands.insert(
+                key.clone(),
+                VisitMark {
+                    generation: self.generation,
+                    active: true,
+                },
+            );
+        }
     }
 }
 
@@ -751,11 +1013,11 @@ pub fn lookup_resources_with_snapshot(
             .reverse_query_compact_relationships(&subject_filter)
         {
             let object = relationship.resource_object_legacy();
-            if relationship.resource_type_eq(&resource_type)
-                && seen.insert(object.clone())
-                && check_context
-                    .check(&object, &request.permission, &request.subject)?
-                    .is_allowed()
+            if relationship.resource_type_eq(&resource_type) && seen.insert(object.clone()) && {
+                check_context.reset_for_reuse();
+                check_context.check(&object, &request.permission, &request.subject)?
+            }
+            .is_allowed()
             {
                 resources.push(object.clone());
                 if lookup_result_limit_reached(resources.len(), limits) {
@@ -819,25 +1081,8 @@ pub fn lookup_subjects_with_snapshot(
     Ok(LookupSubjects { subjects })
 }
 
-fn indexed_resource_relation<'a>(
-    relationships: &'a RelationshipStoreView,
-    object: &Object,
-    relation_name: &RelationName,
-    limit: QueryLimit,
-) -> Result<StoreViewCompactIter<'a>, ZanzibarError> {
-    let resource = DomainObjectRef::try_from(object)?;
-    let filter = RelationshipFilter::new(
-        ObjectType::try_from(object.namespace.as_str())?,
-        Some(resource.object_id().clone()),
-        Some(relation_name.clone()),
-        None,
-        limit,
-    );
-    Ok(relationships.query_compact_relationships(&filter))
-}
-
-fn legacy_relation(relation: &RelationName) -> Relation {
-    Relation(relation.as_str().to_string())
+fn compiled_schema_invariant_error() -> ZanzibarError {
+    ZanzibarError::StorageError("compiled schema relation id is out of bounds".to_string())
 }
 
 struct LookupSubjectCollector<'a, 'ctx> {
@@ -860,11 +1105,12 @@ impl LookupSubjectCollector<'_, '_> {
         match expanded {
             ExpandedUserset::User(id) if self.subject_type.as_str() == "user" => {
                 let subject = User::UserId(id.clone());
-                if self.seen_subjects.insert(subject.clone())
-                    && self
-                        .check_context
+                if self.seen_subjects.insert(subject.clone()) && {
+                    self.check_context.reset_for_reuse();
+                    self.check_context
                         .check(self.resource, self.permission, &subject)?
-                        .is_allowed()
+                }
+                .is_allowed()
                 {
                     self.subjects.push(subject);
                 }
@@ -900,10 +1146,12 @@ impl LookupSubjectCollector<'_, '_> {
         let userset = User::Userset(object.clone(), relation.clone());
         if object.namespace == self.subject_type.as_str()
             && self.seen_subjects.insert(userset.clone())
-            && self
-                .check_context
-                .check(self.resource, self.permission, &userset)?
-                .is_allowed()
+            && {
+                self.check_context.reset_for_reuse();
+                self.check_context
+                    .check(self.resource, self.permission, &userset)?
+            }
+            .is_allowed()
         {
             self.subjects.push(userset);
             if lookup_result_limit_reached(self.subjects.len(), self.limits) {
@@ -914,6 +1162,7 @@ impl LookupSubjectCollector<'_, '_> {
             .seen_usersets
             .insert((object.clone(), relation.clone()))
         {
+            self.expand_context.reset_for_reuse();
             let nested = self.expand_context.expand(object, relation)?;
             self.collect(&nested)?;
         }

--- a/src/relationship.rs
+++ b/src/relationship.rs
@@ -1,5 +1,7 @@
 //! Indexed in-memory relationship store and mutation semantics.
 
+#[cfg(feature = "bench-internals")]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     collections::{
         BTreeMap, HashMap, HashSet,
@@ -49,6 +51,53 @@ const INDEX_DIRECTORY_KEY_WIDTH_SHIFT: u16 = 1;
 const INDEX_DIRECTORY_KEY_WIDTH_MASK: u16 = 0b110;
 const SNAPSHOT_INDEX_KIND_COUNT: usize = 7;
 const SNAPSHOT_INDEX_KIND_COUNT_U64: u64 = SNAPSHOT_INDEX_KIND_COUNT as u64;
+#[cfg(feature = "bench-internals")]
+static DELTA_SEGMENTS_INSPECTED: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "bench-internals")]
+static TOMBSTONE_CHECKS: AtomicU64 = AtomicU64::new(0);
+
+/// Benchmark-only read counters for segmented relationship views.
+#[cfg(feature = "bench-internals")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StoreViewReadCounters {
+    /// Number of delta overlays inspected by read queries.
+    pub delta_segments_inspected: u64,
+    /// Number of checkpoint rows tested against the delta tombstone set.
+    pub tombstone_checks: u64,
+}
+
+/// Resets benchmark-only segmented-store read counters.
+#[cfg(feature = "bench-internals")]
+pub fn reset_store_view_read_counters() {
+    DELTA_SEGMENTS_INSPECTED.store(0, Ordering::Relaxed);
+    TOMBSTONE_CHECKS.store(0, Ordering::Relaxed);
+}
+
+/// Returns benchmark-only segmented-store read counters.
+#[cfg(feature = "bench-internals")]
+#[must_use]
+pub fn store_view_read_counters() -> StoreViewReadCounters {
+    StoreViewReadCounters {
+        delta_segments_inspected: DELTA_SEGMENTS_INSPECTED.load(Ordering::Relaxed),
+        tombstone_checks: TOMBSTONE_CHECKS.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(feature = "bench-internals")]
+fn record_delta_segment_inspected() {
+    DELTA_SEGMENTS_INSPECTED.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(not(feature = "bench-internals"))]
+fn record_delta_segment_inspected() {}
+
+#[cfg(feature = "bench-internals")]
+fn record_tombstone_check() {
+    TOMBSTONE_CHECKS.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(not(feature = "bench-internals"))]
+fn record_tombstone_check() {}
 
 /// Errors produced by the indexed relationship store.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -580,6 +629,7 @@ impl RelationshipStoreView {
             checkpoint: Arc::clone(&base.checkpoint),
             delta: Some(StoreDelta {
                 inserted: Arc::new(inserted),
+                deleted_rows: Arc::new(base.deleted_relationship_rows(&deleted)),
                 deleted: Arc::new(deleted),
                 mutation_count,
             }),
@@ -626,13 +676,17 @@ impl RelationshipStoreView {
         &self,
         filter: &RelationshipFilter,
     ) -> StoreViewCompactIter<'_> {
+        let inserted = self
+            .delta
+            .as_ref()
+            .map(|delta| delta.inserted.query_compact_relationships(filter));
+        if inserted.is_some() {
+            record_delta_segment_inspected();
+        }
         StoreViewCompactIter {
-            inserted: self
-                .delta
-                .as_ref()
-                .map(|delta| delta.inserted.query_compact_relationships(filter)),
+            inserted,
             checkpoint: self.checkpoint.query_compact_relationships(filter),
-            deleted: self.delta.as_ref().map(|delta| delta.deleted.as_ref()),
+            deleted: self.delta.as_ref().map(|delta| delta.deleted_rows.as_ref()),
             phase: StoreViewIterPhase::Inserted,
         }
     }
@@ -641,13 +695,73 @@ impl RelationshipStoreView {
         &self,
         filter: &SubjectFilter,
     ) -> StoreViewCompactIter<'_> {
+        let inserted = self
+            .delta
+            .as_ref()
+            .map(|delta| delta.inserted.reverse_query_compact_relationships(filter));
+        if inserted.is_some() {
+            record_delta_segment_inspected();
+        }
         StoreViewCompactIter {
-            inserted: self
-                .delta
-                .as_ref()
-                .map(|delta| delta.inserted.reverse_query_compact_relationships(filter)),
+            inserted,
             checkpoint: self.checkpoint.reverse_query_compact_relationships(filter),
-            deleted: self.delta.as_ref().map(|delta| delta.deleted.as_ref()),
+            deleted: self.delta.as_ref().map(|delta| delta.deleted_rows.as_ref()),
+            phase: StoreViewIterPhase::Inserted,
+        }
+    }
+
+    pub(crate) fn resource_relation(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        limit: QueryLimit,
+    ) -> StoreViewCompactIter<'_> {
+        let inserted = self
+            .delta
+            .as_ref()
+            .map(|delta| delta.inserted.resource_relation(resource, relation, limit));
+        if inserted.is_some() {
+            record_delta_segment_inspected();
+        }
+        StoreViewCompactIter {
+            inserted,
+            checkpoint: self.checkpoint.resource_relation(resource, relation, limit),
+            deleted: self.delta.as_ref().map(|delta| delta.deleted_rows.as_ref()),
+            phase: StoreViewIterPhase::Inserted,
+        }
+    }
+
+    pub(crate) fn any_resource_relation_subject(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        subject: &SubjectFilter,
+    ) -> bool {
+        self.resource_relation_subject(resource, relation, subject)
+            .next()
+            .is_some()
+    }
+
+    fn resource_relation_subject(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        subject: &SubjectFilter,
+    ) -> StoreViewCompactIter<'_> {
+        let inserted = self.delta.as_ref().map(|delta| {
+            delta
+                .inserted
+                .resource_relation_subject(resource, relation, subject)
+        });
+        if inserted.is_some() {
+            record_delta_segment_inspected();
+        }
+        StoreViewCompactIter {
+            inserted,
+            checkpoint: self
+                .checkpoint
+                .resource_relation_subject(resource, relation, subject),
+            deleted: self.delta.as_ref().map(|delta| delta.deleted_rows.as_ref()),
             phase: StoreViewIterPhase::Inserted,
         }
     }
@@ -821,11 +935,24 @@ impl RelationshipStoreView {
         }
         Ok(store)
     }
+
+    fn deleted_relationship_rows(
+        &self,
+        deleted: &HashSet<Relationship>,
+    ) -> HashSet<RelationshipRow> {
+        deleted
+            .iter()
+            .filter_map(|relationship| {
+                RelationshipRow::from_existing_relationship(relationship, &self.checkpoint.interner)
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone)]
 struct StoreDelta {
     inserted: Arc<IndexedRelationshipStore>,
+    deleted_rows: Arc<HashSet<RelationshipRow>>,
     deleted: Arc<HashSet<Relationship>>,
     mutation_count: NonZeroUsize,
 }
@@ -842,7 +969,7 @@ enum RelationshipLocation {
 pub(crate) struct StoreViewCompactIter<'a> {
     inserted: Option<CompactRelationshipIter<'a>>,
     checkpoint: CompactRelationshipIter<'a>,
-    deleted: Option<&'a HashSet<Relationship>>,
+    deleted: Option<&'a HashSet<RelationshipRow>>,
     phase: StoreViewIterPhase,
 }
 
@@ -862,11 +989,14 @@ impl<'a> Iterator for StoreViewCompactIter<'a> {
                 }
                 StoreViewIterPhase::Checkpoint => {
                     let relationship = self.checkpoint.next()?;
-                    if self
-                        .deleted
-                        .is_none_or(|deleted| !relationship.is_deleted_by(deleted))
-                    {
-                        return Some(relationship);
+                    match self.deleted {
+                        Some(deleted) => {
+                            record_tombstone_check();
+                            if !relationship.is_deleted_by(deleted) {
+                                return Some(relationship);
+                            }
+                        }
+                        None => return Some(relationship),
                     }
                 }
             }
@@ -1272,6 +1402,42 @@ impl IndexedRelationshipStore {
         }
     }
 
+    pub(crate) fn resource_relation(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        limit: QueryLimit,
+    ) -> CompactRelationshipIter<'_> {
+        let matcher = self.resource_relation_matcher(resource, relation, limit);
+        let candidates = matcher.as_ref().map_or(CandidateRowIds::Empty, |matcher| {
+            self.resource_candidate_row_ids(matcher)
+        });
+        CompactRelationshipIter {
+            store: self,
+            all_rows_live: self.live_rows.is_all_live(),
+            candidates,
+            matcher: matcher.map(CompactRelationshipMatcher::Resource),
+        }
+    }
+
+    fn resource_relation_subject(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        subject: &SubjectFilter,
+    ) -> CompactRelationshipIter<'_> {
+        let matcher = self.resource_relation_subject_matcher(resource, relation, subject);
+        let candidates = matcher.as_ref().map_or(CandidateRowIds::Empty, |matcher| {
+            self.resource_candidate_row_ids(matcher)
+        });
+        CompactRelationshipIter {
+            store: self,
+            all_rows_live: self.live_rows.is_all_live(),
+            candidates,
+            matcher: matcher.map(CompactRelationshipMatcher::Resource),
+        }
+    }
+
     pub(crate) const fn index_profile(&self) -> IndexProfile {
         self.index_profile
     }
@@ -1477,6 +1643,35 @@ impl IndexedRelationshipStore {
             optional_subject,
             remaining: filter.limit.get(),
         })
+    }
+
+    fn resource_relation_matcher(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        limit: QueryLimit,
+    ) -> Option<ResourceMatcher> {
+        Some(ResourceMatcher {
+            resource_type: ObjectTypeId(self.interner.lookup(resource.object_type().as_str())?),
+            optional_resource_id: Some(ObjectIdId(
+                self.interner.lookup(resource.object_id().as_str())?,
+            )),
+            optional_relation: Some(RelationId(self.interner.lookup(relation.as_str())?)),
+            optional_subject: None,
+            remaining: limit.get(),
+        })
+    }
+
+    fn resource_relation_subject_matcher(
+        &self,
+        resource: &ObjectRef,
+        relation: &RelationName,
+        subject: &SubjectFilter,
+    ) -> Option<ResourceMatcher> {
+        let mut matcher =
+            self.resource_relation_matcher(resource, relation, QueryLimit::new(NonZeroUsize::MIN))?;
+        matcher.optional_subject = Some(self.subject_matcher(subject)?);
+        Some(matcher)
     }
 
     fn subject_matcher(&self, filter: &SubjectFilter) -> Option<SubjectMatcher> {
@@ -1791,10 +1986,8 @@ pub(crate) struct RelationshipRef<'a> {
 }
 
 impl RelationshipRef<'_> {
-    fn is_deleted_by(&self, deleted: &HashSet<Relationship>) -> bool {
-        self.store
-            .relationship_from_row(self.row)
-            .is_ok_and(|relationship| deleted.contains(&relationship))
+    fn is_deleted_by(&self, deleted: &HashSet<RelationshipRow>) -> bool {
+        deleted.contains(self.row)
     }
 
     pub(crate) fn resource_object_legacy(&self) -> crate::model::Object {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -322,6 +322,8 @@ pub(crate) enum CompiledUsersetExpression {
         relation: RelationName,
         /// Referenced relation id retained for schema lookup.
         relation_id: SchemaRelationId,
+        /// Whether the referenced relation has its own rewrite.
+        target_has_rewrite: bool,
     },
     /// A relation reached through userset subjects on another relation.
     TupleToUserset {
@@ -678,9 +680,14 @@ fn compile_resolved_expression(
     match expression {
         UsersetExpression::This => Ok(CompiledUsersetExpression::This),
         UsersetExpression::ComputedUserset { relation } => {
+            let target_has_rewrite = resolver
+                .relation(namespace, relation)?
+                .userset_rewrite()
+                .is_some();
             Ok(CompiledUsersetExpression::ComputedUserset {
                 relation: relation.clone(),
                 relation_id: resolver.relation_id(namespace, relation)?,
+                target_has_rewrite,
             })
         }
         UsersetExpression::TupleToUserset {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -135,7 +135,9 @@ impl CompiledSchema {
         let definitions = definitions.into_iter().collect::<Vec<_>>();
         let compiled = Self::new(Arc::from(definitions.into_boxed_slice()))?;
         validate_references(&compiled)?;
-        Ok(compiled)
+        Self::new(Arc::from(
+            compile_resolved_definitions(&compiled)?.into_boxed_slice(),
+        ))
     }
 
     /// Returns all namespace definitions in source order.
@@ -201,6 +203,7 @@ pub struct RelationDefinition {
     name: RelationName,
     allowed_subject_types: AllowedSubjectTypes,
     userset_rewrite: Option<UsersetExpression>,
+    compiled_userset_rewrite: Option<CompiledUsersetExpression>,
 }
 
 impl RelationDefinition {
@@ -211,6 +214,7 @@ impl RelationDefinition {
             name,
             allowed_subject_types: AllowedSubjectTypes::Unspecified,
             userset_rewrite,
+            compiled_userset_rewrite: None,
         }
     }
 
@@ -225,6 +229,7 @@ impl RelationDefinition {
             name,
             allowed_subject_types: AllowedSubjectTypes::Explicit(allowed_subject_types),
             userset_rewrite,
+            compiled_userset_rewrite: None,
         }
     }
 
@@ -244,6 +249,10 @@ impl RelationDefinition {
     #[must_use]
     pub fn userset_rewrite(&self) -> Option<&UsersetExpression> {
         self.userset_rewrite.as_ref()
+    }
+
+    pub(crate) fn compiled_userset_rewrite(&self) -> Option<&CompiledUsersetExpression> {
+        self.compiled_userset_rewrite.as_ref()
     }
 }
 
@@ -283,6 +292,58 @@ pub enum UsersetExpression {
         base: Box<UsersetExpression>,
         /// Expression to subtract.
         exclude: Box<UsersetExpression>,
+    },
+}
+
+/// Stable relation identifier inside one compiled schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SchemaRelationId {
+    namespace_index: usize,
+    relation_index: usize,
+}
+
+impl SchemaRelationId {
+    const fn new(namespace_index: usize, relation_index: usize) -> Self {
+        Self {
+            namespace_index,
+            relation_index,
+        }
+    }
+}
+
+/// Userset expression with same-namespace relation edges resolved to schema ids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompiledUsersetExpression {
+    /// Direct relationships stored on this object and relation.
+    This,
+    /// A relation on the same object.
+    ComputedUserset {
+        /// Referenced relation name retained for store lookup.
+        relation: RelationName,
+        /// Referenced relation id retained for schema lookup.
+        relation_id: SchemaRelationId,
+    },
+    /// A relation reached through userset subjects on another relation.
+    TupleToUserset {
+        /// Relation containing intermediate userset subjects.
+        tupleset_relation: RelationName,
+        /// Same-namespace id for the tupleset relation.
+        tupleset_relation_id: SchemaRelationId,
+        /// Relation to evaluate on each intermediate object. This remains name-based because the
+        /// intermediate object's namespace determines the target schema relation at evaluation
+        /// time.
+        computed_userset_relation: RelationName,
+    },
+    /// Union of child expressions.
+    Union(Vec<CompiledUsersetExpression>),
+    /// Intersection of child expressions.
+    Intersection(Vec<CompiledUsersetExpression>),
+    /// Exclusion of one expression from another.
+    Exclusion {
+        /// Base expression.
+        base: Box<CompiledUsersetExpression>,
+        /// Expression to subtract.
+        exclude: Box<CompiledUsersetExpression>,
     },
 }
 
@@ -396,6 +457,43 @@ impl SchemaResolver {
                 namespace: object_type.to_string(),
                 relation: relation.to_string(),
             })
+    }
+
+    pub(crate) fn relation_id(
+        &self,
+        object_type: &ObjectType,
+        relation: &RelationName,
+    ) -> Result<SchemaRelationId, SchemaError> {
+        let namespace_index = self
+            .namespace_indexes
+            .get(object_type)
+            .copied()
+            .ok_or_else(|| SchemaError::NamespaceNotFound {
+                namespace: object_type.to_string(),
+            })?;
+        let relations = self.relation_indexes.get(object_type).ok_or_else(|| {
+            SchemaError::NamespaceNotFound {
+                namespace: object_type.to_string(),
+            }
+        })?;
+        let relation_index =
+            relations
+                .get(relation)
+                .copied()
+                .ok_or_else(|| SchemaError::RelationNotFound {
+                    namespace: object_type.to_string(),
+                    relation: relation.to_string(),
+                })?;
+        Ok(SchemaRelationId::new(namespace_index, relation_index))
+    }
+
+    pub(crate) fn relation_by_id(
+        &self,
+        relation_id: SchemaRelationId,
+    ) -> Option<&RelationDefinition> {
+        self.definitions
+            .get(relation_id.namespace_index)
+            .and_then(|namespace| namespace.relations().get(relation_id.relation_index))
     }
 
     pub(crate) fn sorted_relations(
@@ -541,6 +639,74 @@ fn compile_legacy_expression(
             base: Box::new(compile_legacy_expression(*base)?),
             exclude: Box::new(compile_legacy_expression(*exclude)?),
         }),
+    }
+}
+
+fn compile_resolved_definitions(
+    compiled: &CompiledSchema,
+) -> Result<Vec<NamespaceDefinition>, SchemaError> {
+    let mut namespaces = Vec::with_capacity(compiled.definitions().len());
+    for namespace in compiled.definitions() {
+        let mut relations = Vec::with_capacity(namespace.relations().len());
+        for relation in namespace.relations() {
+            let compiled_userset_rewrite = relation
+                .userset_rewrite()
+                .map(|expression| {
+                    compile_resolved_expression(compiled.resolver(), namespace.name(), expression)
+                })
+                .transpose()?;
+            relations.push(RelationDefinition {
+                name: relation.name.clone(),
+                allowed_subject_types: relation.allowed_subject_types.clone(),
+                userset_rewrite: relation.userset_rewrite.clone(),
+                compiled_userset_rewrite,
+            });
+        }
+        namespaces.push(NamespaceDefinition::new(
+            namespace.name.clone(),
+            Arc::from(relations.into_boxed_slice()),
+        ));
+    }
+    Ok(namespaces)
+}
+
+fn compile_resolved_expression(
+    resolver: &SchemaResolver,
+    namespace: &ObjectType,
+    expression: &UsersetExpression,
+) -> Result<CompiledUsersetExpression, SchemaError> {
+    match expression {
+        UsersetExpression::This => Ok(CompiledUsersetExpression::This),
+        UsersetExpression::ComputedUserset { relation } => {
+            Ok(CompiledUsersetExpression::ComputedUserset {
+                relation: relation.clone(),
+                relation_id: resolver.relation_id(namespace, relation)?,
+            })
+        }
+        UsersetExpression::TupleToUserset {
+            tupleset_relation,
+            computed_userset_relation,
+        } => Ok(CompiledUsersetExpression::TupleToUserset {
+            tupleset_relation: tupleset_relation.clone(),
+            tupleset_relation_id: resolver.relation_id(namespace, tupleset_relation)?,
+            computed_userset_relation: computed_userset_relation.clone(),
+        }),
+        UsersetExpression::Union(expressions) => expressions
+            .iter()
+            .map(|expression| compile_resolved_expression(resolver, namespace, expression))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CompiledUsersetExpression::Union),
+        UsersetExpression::Intersection(expressions) => expressions
+            .iter()
+            .map(|expression| compile_resolved_expression(resolver, namespace, expression))
+            .collect::<Result<Vec<_>, _>>()
+            .map(CompiledUsersetExpression::Intersection),
+        UsersetExpression::Exclusion { base, exclude } => {
+            Ok(CompiledUsersetExpression::Exclusion {
+                base: Box::new(compile_resolved_expression(resolver, namespace, base)?),
+                exclude: Box::new(compile_resolved_expression(resolver, namespace, exclude)?),
+            })
+        }
     }
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -742,7 +742,7 @@ fn load_snapshot_file_inner(
         &reader,
         options.profile,
         options.validation,
-        timings.as_deref_mut(),
+        &mut timings,
     )?;
     let phase_start = Instant::now();
     let configs = configs_vec
@@ -892,10 +892,12 @@ fn decode_relationships_with_optional_timings(
     reader: &SnapshotReader<'_>,
     profile: SnapshotLoadProfile,
     validation: SnapshotValidationMode,
-    timings: Option<&mut SnapshotLoadPhaseTimings>,
+    timings: &mut Option<&mut SnapshotLoadPhaseTimings>,
 ) -> Result<Arc<RelationshipStoreView>, SnapshotIoError> {
+    #[cfg(not(feature = "bench-internals"))]
+    let _ = timings;
     #[cfg(feature = "bench-internals")]
-    if let Some(timings) = timings {
+    if let Some(timings) = timings.as_deref_mut() {
         let store = Arc::new(
             IndexedRelationshipStore::decode_snapshot_sections_with_timings(
                 reader, profile, validation, timings,
@@ -903,7 +905,6 @@ fn decode_relationships_with_optional_timings(
         );
         return Ok(Arc::new(RelationshipStoreView::from_checkpoint(store)));
     }
-    let _ = timings;
     let store = Arc::new(IndexedRelationshipStore::decode_snapshot_sections(
         reader, profile, validation,
     )?);

--- a/tests/performance_optimization_tests.rs
+++ b/tests/performance_optimization_tests.rs
@@ -198,6 +198,128 @@ fn test_should_save_canonical_snapshot_from_segmented_delta_view()
     Ok(())
 }
 
+#[test]
+fn test_should_preserve_delta_tombstone_masking_for_lookup()
+-> Result<(), Box<dyn std::error::Error>> {
+    let engine = seeded_engine()?;
+    engine.write_relationships([
+        RelationshipMutation::delete("doc:one#viewer@user:alice")?,
+        RelationshipMutation::touch("doc:three#viewer@user:alice")?,
+    ])?;
+
+    let resources = engine.lookup_resources(LookupResourcesRequest::new(
+        User::user_id("alice"),
+        relation("viewer"),
+        "doc",
+    ))?;
+
+    let actual = resources.resources.into_iter().collect::<HashSet<_>>();
+    let expected = HashSet::from([object("doc", "two"), object("doc", "three")]);
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[test]
+fn test_should_keep_plain_computed_shortcut_conservative_for_deny_and_intersection()
+-> Result<(), Box<dyn std::error::Error>> {
+    let engine = ZanzibarEngine::builder().build();
+    engine.add_dsl(
+        r#"
+        namespace doc {
+            relation owner {}
+            relation reviewer {}
+            relation banned {}
+            relation visible {
+                rewrite exclusion(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "banned")
+                )
+            }
+            relation approved {
+                rewrite intersection(
+                    computed_userset(relation: "owner"),
+                    computed_userset(relation: "reviewer")
+                )
+            }
+        }
+        "#,
+    )?;
+    engine.write_relationships([
+        RelationshipMutation::touch("doc:one#owner@user:alice")?,
+        RelationshipMutation::touch("doc:one#banned@user:alice")?,
+        RelationshipMutation::touch("doc:one#reviewer@user:bob")?,
+    ])?;
+
+    assert!(!engine.check_relation(
+        &object("doc", "one"),
+        &relation("visible"),
+        &User::user_id("alice"),
+    )?);
+    assert!(!engine.check_relation(
+        &object("doc", "one"),
+        &relation("approved"),
+        &User::user_id("alice"),
+    )?);
+    Ok(())
+}
+
+#[test]
+fn test_should_not_leak_reusable_lookup_context_between_candidates()
+-> Result<(), Box<dyn std::error::Error>> {
+    let engine = ZanzibarEngine::builder().build();
+    engine.add_dsl(
+        r#"
+        namespace doc {
+            relation viewer {}
+            relation can_view {
+                rewrite computed_userset(relation: "viewer")
+            }
+        }
+        "#,
+    )?;
+    engine.write_relationships([
+        RelationshipMutation::touch("doc:one#viewer@user:alice")?,
+        RelationshipMutation::touch("doc:two#viewer@user:alice")?,
+    ])?;
+
+    let resources = engine.lookup_resources(LookupResourcesRequest::new(
+        User::user_id("alice"),
+        relation("can_view"),
+        "doc",
+    ))?;
+
+    assert_eq!(
+        resources.resources,
+        vec![object("doc", "one"), object("doc", "two")]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_should_preserve_cycle_denial_with_compiled_relation_ids()
+-> Result<(), Box<dyn std::error::Error>> {
+    let engine = ZanzibarEngine::builder().build();
+    engine.add_dsl(
+        r#"
+        namespace doc {
+            relation first {
+                rewrite computed_userset(relation: "second")
+            }
+            relation second {
+                rewrite computed_userset(relation: "first")
+            }
+        }
+        "#,
+    )?;
+
+    assert!(!engine.check_relation(
+        &object("doc", "one"),
+        &relation("first"),
+        &User::user_id("alice"),
+    )?);
+    Ok(())
+}
+
 proptest! {
     #[test]
     fn test_should_match_reference_set_for_segmented_delta_publication(


### PR DESCRIPTION
## Summary
- Complete the remaining M13 / Phase 14 read-path refinements after the zstd-aware snapshot-load work.
- Compile same-namespace schema relation edges to internal relation ids and remove recursive public `Relation` materialization on relation-name paths.
- Add segment-native resource/relation scans and checkpoint-native delta tombstone masking.
- Reuse lookup verification contexts with generation-scoped active indexes while preserving the pure stack path for one-shot checks.
- Add conservative exact computed-userset shortcuts plus adversarial regression coverage.

## Benchmark Summary
- `realworld_authorization/1m_rules/mixed_read_workload`: `[41.599 us, 42.085 us, 42.690 us]`, under the 55 us gate.
- `realworld_authorization/1m_rules/check_doc_inherited_workspace_member`: `[11.540 us, 11.599 us, 11.646 us]`, under the 13.5 us stretch gate.
- `perf_optimization/check_prepared_1m`: `[4.3107 us, 4.3867 us, 4.4450 us]`.
- `perf_optimization/lookup_resources_streaming_1m`: `[2.2853 ms, 2.3241 ms, 2.3551 ms]`.
- `perf_optimization/lookup_subjects_streaming_1m`: `[4.6735 us, 4.7194 us, 4.7426 us]`.

## Verification
- `cargo build --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --all-features`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing -W clippy::panic`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `cargo audit`
- `cargo deny check` (exit 0; existing warning-level unmatched-license allowlist and duplicate `cpufeatures` notices remain)

Benchmark details are posted as PR comments.