### PR TITLE
Hardening production readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,17 @@ check: build test fmt-check clippy
 test:
 	@cargo nextest run --all-features
 
+prod-ready-check: build test fmt-check lint audit deny doc
+
+audit:
+	@cargo audit
+
+deny:
+	@cargo deny check
+
+doc:
+	@RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+
 bench-baseline:
 	@cargo bench --bench baseline -- --sample-size 10
 
@@ -73,6 +84,11 @@ bench-perf-continuous:
 	@cargo bench --features bench-internals --bench perf_optimization -- lookup_subjects_streaming_1m --sample-size "$${PERF_SAMPLE_SIZE:-10}"
 	@cargo bench --features bench-internals --bench perf_optimization -- read_heavy_heavy_write_batched_1m --sample-size "$${PERF_SAMPLE_SIZE:-10}"
 
+bench-prod-smoke:
+	@cargo bench --features bench-internals --bench perf_optimization -- check_prepared_1m --sample-size "$${PERF_SAMPLE_SIZE:-10}"
+	@cargo bench --features bench-internals --bench perf_optimization -- lookup_resources_streaming_1m --sample-size "$${PERF_SAMPLE_SIZE:-10}"
+	@cargo bench --bench snapshot -- snapshot_load_trusted_fast/1m --sample-size "$${PERF_SAMPLE_SIZE:-10}"
+
 bench-snapshot-memory:
 	@cargo bench --bench snapshot --no-run
 	@set -e; \
@@ -133,4 +149,4 @@ release:
 update-submodule:
 	@git submodule update --init --recursive --remote
 
-.PHONY: build check test bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-concurrent-runtime bench-realworld bench-perf-optimization bench-read-followup-baseline bench-snapshot-section-size perf-charts perf-charts-check perf-history-ingest perf-tools-check perf-impact-chart phase-benchmark-trends bench-perf-continuous bench-snapshot-memory bench-snapshot-zstd-memory bench-all fmt fmt-check clippy lint release update-submodule
+.PHONY: build check test prod-ready-check audit deny doc bench-baseline bench-org bench-org-memory bench-snapshot bench-public-api bench-concurrent-runtime bench-realworld bench-perf-optimization bench-read-followup-baseline bench-snapshot-section-size perf-charts perf-charts-check perf-history-ingest perf-tools-check perf-impact-chart phase-benchmark-trends bench-perf-continuous bench-prod-smoke bench-snapshot-memory bench-snapshot-zstd-memory bench-all fmt fmt-check clippy lint release update-submodule

--- a/README.md
+++ b/README.md
@@ -5,191 +5,126 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://github.com/tyrchen/simple-zanzibar/workflows/CI/badge.svg)](https://github.com/tyrchen/simple-zanzibar/actions)
 
-A simplified Rust implementation of Google's Zanzibar authorization system, featuring a human-readable DSL for policy definition and comprehensive support for relationship-based access control (ReBAC).
+Simple Zanzibar is a local, in-memory Rust authorization engine inspired by Google's Zanzibar paper.
+It provides relationship-based access control (ReBAC), a small policy DSL, consistency tokens,
+lock-free snapshot reads, compact snapshot artifacts, and public APIs for check, expand, lookup, and
+policy review workflows.
 
-## 🌟 What is Zanzibar?
+The crate is intentionally a local library, not a distributed Zanzibar service. It is useful when an
+application wants Zanzibar-style semantics in-process and can distribute policy/relationship data as
+text or prebuilt `.szsnap` artifacts.
 
-[Google's Zanzibar](https://research.google/pubs/pub48190/) is a global authorization system that provides consistent, scalable authorization decisions across Google's services. It's based on the concept of **relationship tuples** that express relationships between objects and users.
+## Current Capabilities
 
-### Key Concepts
+- Schema-first DSL with direct relations, computed usersets, tuple-to-userset inheritance, union,
+  intersection, and exclusion.
+- Validated relationship strings such as `doc:readme#viewer@group:eng#member`.
+- Single-writer actor with bounded queue; readers use immutable published snapshots through
+  `arc-swap` and do not take a service-level lock.
+- Consistency tokens for exact-snapshot reads across retained revisions.
+- Indexed compact relationship storage for resource-side and subject-side lookup paths.
+- `check`, `expand`, `lookup_resources`, `lookup_subjects`, `lookup_permissions`, and
+  `lookup_object_permissions` APIs.
+- Deterministic policy text import/export and raw or zstd-compressed snapshot save/load.
+- Optional `serde` feature with validated public request/response DTO deserialization.
+- Optional `tracing` feature for structured API spans.
 
-- **Objects**: Resources in your system (e.g., `doc:readme`, `folder:photos`)
-- **Relations**: Types of relationships (e.g., `owner`, `viewer`, `editor`)
-- **Users**: Subjects that can have relationships (e.g., `user:alice`, `group:engineers`)
-- **Tuples**: Assertions of relationships (e.g., `doc:readme#owner@user:alice`)
+## Architecture
 
-## 🏗️ Architecture
-
-```mermaid
-graph TB
-    subgraph "Simple Zanzibar Architecture"
-        DSL[DSL Parser] --> Config[Namespace Config]
-        Config --> Service[Zanzibar Service]
-
-        Service --> Store[Tuple Store]
-        Service --> Eval[Evaluation Engine]
-
-        Store --> Memory[In-Memory Store]
-        Store --> Future[Future: Database Store]
-
-        Eval --> Check[Check API]
-        Eval --> Expand[Expand API]
-
-        Check --> Decision{Authorization Decision}
-        Expand --> Userset[Expanded Userset]
-    end
-
-    subgraph "External Interface"
-        Client[Client Application] --> Service
-        Policy[Policy Definition] --> DSL
-    end
-
-    style Service fill:#e1f5fe
-    style DSL fill:#f3e5f5
-    style Eval fill:#e8f5e8
-    style Store fill:#fff3e0
+```text
+Client / application
+        │
+        ▼
+┌───────────────────────────────┐
+│ ZanzibarEngine public API      │
+│ - validates request DTOs       │
+│ - starts tracing spans         │
+└───────────────┬───────────────┘
+                │
+    ┌───────────┴───────────┐
+    │                       │
+    ▼                       ▼
+Read path               Write path
+ArcSwap snapshot        bounded writer actor
+check/expand/lookup     schema + relationship mutation
+    │                       │
+    ▼                       ▼
+Compiled schema IR      publish new revision token
+Indexed store view      retain exact snapshots
+    │                       │
+    └───────────┬───────────┘
+                ▼
+        `.szsnap` save/load
+        raw or zstd wrapper
 ```
 
-## 🔄 Data Flow
+## Quick Start
 
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Service as ZanzibarEngine
-    participant Parser as DSL Parser
-    participant Store as Tuple Store
-    participant Eval as Evaluation Engine
-
-    Note over Client,Eval: Policy Setup
-    Client->>Service: add_dsl(policy)
-    Service->>Parser: parse_dsl(policy)
-    Parser-->>Service: NamespaceConfig
-
-    Note over Client,Eval: Tuple Management
-    Client->>Service: write_tuple(tuple)
-    Service->>Store: write_tuple(tuple)
-    Store-->>Service: Ok()
-
-    Note over Client,Eval: Authorization Check
-    Client->>Service: check(object, relation, user)
-    Service->>Eval: check(object, relation, user, config, store)
-    Eval->>Store: read_tuples(filter)
-    Store-->>Eval: Vec<RelationTuple>
-    Eval->>Eval: recursive_evaluation()
-    Eval-->>Service: bool
-    Service-->>Client: Authorization Result
-```
-
-## 📊 Entity Relationship
-
-```mermaid
-erDiagram
-    NAMESPACE {
-        string name
-        map relations
-    }
-
-    RELATION_CONFIG {
-        string name
-        optional userset_rewrite
-    }
-
-    USERSET_EXPRESSION {
-        enum type
-        optional relation
-        optional expressions
-    }
-
-    OBJECT {
-        string namespace
-        string id
-    }
-
-    RELATION {
-        string name
-    }
-
-    USER {
-        enum type
-        string user_id
-        optional object
-        optional relation
-    }
-
-    RELATION_TUPLE {
-        object object
-        relation relation
-        user user
-    }
-
-    NAMESPACE ||--o{ RELATION_CONFIG : contains
-    RELATION_CONFIG ||--o| USERSET_EXPRESSION : has
-    USERSET_EXPRESSION ||--o{ USERSET_EXPRESSION : composed_of
-    RELATION_TUPLE ||--|| OBJECT : references
-    RELATION_TUPLE ||--|| RELATION : has
-    RELATION_TUPLE ||--|| USER : assigned_to
-```
-
-## 🚀 Quick Start
-
-Add this to your `Cargo.toml`:
+Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-simple-zanzibar = "0.1.0"
+simple-zanzibar = "0.2.1"
 ```
 
-### Basic Usage
+Basic permission check:
 
 ```rust
-use simple_zanzibar::{ZanzibarEngine, model::{Object, Relation, RelationTuple, User}};
+use simple_zanzibar::{
+    ZanzibarEngine,
+    model::{Object, Relation, User},
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let service = ZanzibarEngine::builder().build();
+    let engine = ZanzibarEngine::builder().build();
 
-    // Define policy using DSL
-    let policy = r#"
+    engine.add_dsl(r#"
         namespace doc {
             relation owner {}
             relation viewer {
                 rewrite union(this, computed_userset(relation: "owner"))
             }
         }
-    "#;
+    "#)?;
 
-    service.add_dsl(policy)?;
+    engine.touch_relationship("doc:readme#owner@user:alice")?;
 
-    // Create objects and users
-    let doc = Object { namespace: "doc".to_string(), id: "readme".to_string() };
-    let alice = User::UserId("alice".to_string());
+    let doc = Object::new("doc", "readme");
+    let viewer = Relation::new("viewer");
+    let alice = User::user_id("alice");
 
-    // Grant permission
-    service.write_tuple(RelationTuple {
-        object: doc.clone(),
-        relation: Relation("owner".to_string()),
-        user: alice.clone(),
-    })?;
-
-    // Check permission
-    let can_view = service.check_relation(
-        &doc,
-        &Relation("viewer".to_string()),
-        &alice
-    )?;
-
-    println!("Alice can view doc: {}", can_view); // true
-
+    assert!(engine.check_relation(&doc, &viewer, &alice)?);
     Ok(())
 }
 ```
 
-## 📝 DSL Reference
+Exact consistency after a write:
 
-The Simple Zanzibar DSL allows you to define authorization policies in a human-readable format.
+```rust
+use simple_zanzibar::{
+    ZanzibarEngine,
+    model::{CheckRequest, Object, Relation, User},
+    revision::Consistency,
+};
 
-### Syntax Overview
-
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let engine = ZanzibarEngine::builder().build();
+engine.add_dsl("namespace doc { relation viewer {} }")?;
+let token = engine.touch_relationship("doc:readme#viewer@user:alice")?;
+let response = engine.check(CheckRequest::new(
+    Object::new("doc", "readme"),
+    Relation::new("viewer"),
+    User::user_id("alice"),
+    Consistency::Exact(token),
+))?;
+assert!(response.allowed);
+# Ok(())
+# }
 ```
+
+## DSL Reference
+
+```text
 namespace <namespace_name> {
     relation <relation_name> {
         rewrite <userset_expression>
@@ -197,295 +132,188 @@ namespace <namespace_name> {
 }
 ```
 
-### Userset Expressions
+Supported userset expressions:
 
-#### 1. `this`
+- `this`: direct relationships for the current object relation.
+- `computed_userset(relation: "owner")`: another relation on the same object.
+- `tuple_to_userset(tupleset: "parent", computed_userset: "viewer")`: follow related objects and
+  evaluate a relation on each related object.
+- `union(expr1, expr2, ...)`: any expression may allow access.
+- `intersection(expr1, expr2, ...)`: all expressions must allow access.
+- `exclusion(base, exclude)`: allow `base` except subjects in `exclude`.
 
-Direct relationship - users explicitly granted this relation.
+Example:
 
-```
-relation owner {
-    rewrite this
-}
-```
-
-#### 2. `computed_userset(relation: "relation_name")`
-
-Users who have another relation on the same object.
-
-```
-relation viewer {
-    rewrite computed_userset(relation: "owner")
-}
-```
-
-#### 3. `tuple_to_userset(tupleset: "relation1", computed_userset: "relation2")`
-
-Users who have `relation2` on objects that have `relation1` with the current object.
-
-```
-relation viewer {
-    rewrite tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
-}
-```
-
-#### 4. `union(expr1, expr2, ...)`
-
-Users who satisfy any of the expressions.
-
-```
-relation viewer {
-    rewrite union(
-        this,
-        computed_userset(relation: "owner"),
-        computed_userset(relation: "editor")
-    )
-}
-```
-
-#### 5. `intersection(expr1, expr2, ...)`
-
-Users who satisfy all expressions.
-
-```
-relation admin {
-    rewrite intersection(
-        computed_userset(relation: "owner"),
-        computed_userset(relation: "manager")
-    )
-}
-```
-
-#### 6. `exclusion(base_expr, exclude_expr)`
-
-Users in `base_expr` but not in `exclude_expr`.
-
-```
-relation editor {
-    rewrite exclusion(
-        computed_userset(relation: "viewer"),
-        computed_userset(relation: "banned")
-    )
-}
-```
-
-### Complete Example
-
-```
-// File system with hierarchical permissions
-namespace file {
-    relation owner {}
-
-    relation parent {}
-
-    relation viewer {
-        rewrite union(
-            this,
-            computed_userset(relation: "owner"),
-            computed_userset(relation: "editor"),
-            tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
-        )
-    }
-
-    relation editor {
-        rewrite union(
-            this,
-            computed_userset(relation: "owner")
-        )
-    }
+```text
+namespace group {
+    relation member {}
 }
 
 namespace folder {
+    relation viewer {}
+}
+
+namespace doc {
     relation owner {}
-
     relation parent {}
-
+    relation banned {}
     relation viewer {
-        rewrite union(
-            this,
-            computed_userset(relation: "owner"),
-            tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
+        rewrite exclusion(
+            union(
+                computed_userset(relation: "owner"),
+                tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
+            ),
+            computed_userset(relation: "banned")
         )
     }
 }
 ```
 
-## 🔧 API Reference
-
-### ZanzibarEngine
-
-The main service for handling authorization.
+## Public API Overview
 
 ```rust
-impl ZanzibarEngine {
-    // Create a new engine
-    pub fn builder() -> ZanzibarEngineBuilder
-
-    // Load policy from DSL
-    pub fn add_dsl(&self, dsl: &str) -> Result<(), EngineError>
-
-    // Add namespace configuration
-    pub fn apply_namespace_config(&self, config: NamespaceConfig) -> Result<ConsistencyToken, EngineError>
-
-    // Write a relation tuple
-    pub fn write_tuple(&self, tuple: impl Borrow<RelationTuple>) -> Result<(), EngineError>
-
-    // Delete a relation tuple
-    pub fn delete_tuple(&self, tuple: &RelationTuple) -> Result<(), EngineError>
-
-    // Check if user has relation to object
-    pub fn check_relation(&self, object: &Object, relation: &Relation, user: &User) -> Result<bool, EngineError>
-
-    // Expand userset for object and relation
-    pub fn expand_relation(&self, object: &Object, relation: &Relation) -> Result<ExpandedUserset, EngineError>
-}
-```
-
-### Data Types
-
-```rust
-// Object represents a resource
-pub struct Object {
-    pub namespace: String,
-    pub id: String,
-}
-
-// Relation represents a permission type
-pub struct Relation(pub String);
-
-// User can be a direct user ID or a userset
-pub enum User {
-    UserId(String),
-    Userset(Object, Relation),
-}
-
-// RelationTuple represents a permission assertion
-pub struct RelationTuple {
-    pub object: Object,
-    pub relation: Relation,
-    pub user: User,
-}
-```
-
-## 📚 Examples
-
-### File Permissions System
-
-```bash
-cargo run --example file_permissions
-```
-
-This example demonstrates:
-
-- Hierarchical file and folder permissions
-- Dynamic permission granting and revocation
-- Permission inheritance through parent relationships
-- Real-world usage patterns
-
-### Custom Implementation
-
-```rust
-use simple_zanzibar::{ZanzibarEngine, model::*};
-
-// Define your domain objects
-let document = Object {
-    namespace: "document".to_string(),
-    id: "proposal.pdf".to_string()
+use simple_zanzibar::{
+    ZanzibarEngine,
+    model::{
+        CheckRequest, ExpandRequest, LookupObjectPermissionsRequest,
+        LookupPermissionsRequest, LookupResourcesRequest, LookupSubjectsRequest,
+    },
+    relationship::{Precondition, RelationshipMutation},
+    revision::ConsistencyToken,
+    schema::SchemaSource,
 };
 
-let user = User::UserId("john.doe".to_string());
-
-// Set up your service with policies
-let service = ZanzibarEngine::builder().build();
-service.add_dsl(r#"
-    namespace document {
-        relation owner {}
-        relation collaborator {}
-        relation viewer {
-            rewrite union(
-                this,
-                computed_userset(relation: "owner"),
-                computed_userset(relation: "collaborator")
-            )
-        }
-    }
-"#)?;
-
-// Grant permissions
-service.write_tuple(RelationTuple {
-    object: document.clone(),
-    relation: Relation("collaborator".to_string()),
-    user: user.clone(),
-})?;
-
-// Check permissions
-let can_view = service.check_relation(
-    &document,
-    &Relation("viewer".to_string()),
-    &user
-)?;
+impl ZanzibarEngine {
+    pub fn builder() -> simple_zanzibar::ZanzibarEngineBuilder;
+    pub fn apply_schema(&self, source: SchemaSource<'_>) -> Result<ConsistencyToken, simple_zanzibar::EngineError>;
+    pub fn write_relationships(
+        &self,
+        mutations: impl IntoIterator<Item = RelationshipMutation>,
+    ) -> Result<ConsistencyToken, simple_zanzibar::EngineError>;
+    pub fn write_relationships_with_preconditions(
+        &self,
+        mutations: impl IntoIterator<Item = RelationshipMutation>,
+        preconditions: impl IntoIterator<Item = Precondition>,
+    ) -> Result<ConsistencyToken, simple_zanzibar::EngineError>;
+    pub fn check(&self, request: CheckRequest) -> Result<simple_zanzibar::model::CheckResponse, simple_zanzibar::EngineError>;
+    pub fn expand(&self, request: ExpandRequest) -> Result<simple_zanzibar::model::ExpandResponse, simple_zanzibar::EngineError>;
+    pub fn lookup_resources(&self, request: impl std::borrow::Borrow<LookupResourcesRequest>) -> Result<simple_zanzibar::model::LookupResources, simple_zanzibar::EngineError>;
+    pub fn lookup_subjects(&self, request: impl std::borrow::Borrow<LookupSubjectsRequest>) -> Result<simple_zanzibar::model::LookupSubjects, simple_zanzibar::EngineError>;
+    pub fn lookup_permissions(&self, request: impl std::borrow::Borrow<LookupPermissionsRequest>) -> Result<simple_zanzibar::model::LookupPermissions, simple_zanzibar::EngineError>;
+    pub fn lookup_object_permissions(&self, request: impl std::borrow::Borrow<LookupObjectPermissionsRequest>) -> Result<simple_zanzibar::model::LookupObjectPermissions, simple_zanzibar::EngineError>;
+}
 ```
 
-## 🧪 Testing
+String convenience methods are available for ergonomic setup:
 
-Run the test suite:
+- `add_dsl` / `add_dsl_with_token`
+- `create_relationship`
+- `touch_relationship`
+- `delete_relationship`
+- `check_relation`
+- `expand_relation`
+
+## Policy Text and Snapshot Artifacts
+
+Reviewable policy text is deterministic and grouped by resource type:
+
+```rust
+use simple_zanzibar::{PolicyText, ZanzibarEngine};
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let policy = PolicyText::from_single_relationship_file(
+    "namespace doc { relation viewer {} }".to_string(),
+    "doc:readme#viewer@user:alice\n".to_string(),
+);
+let engine = ZanzibarEngine::from_policy_text(&policy)?;
+let exported = engine.export_policy_text()?;
+assert!(exported.schema.contains("namespace doc"));
+# Ok(())
+# }
+```
+
+Snapshots are the fastest whole-state distribution format:
+
+```rust
+use simple_zanzibar::{SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine};
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let path = std::env::temp_dir().join("simple-zanzibar-readme.szsnap.zst");
+let engine = ZanzibarEngine::builder().build();
+engine.add_dsl("namespace doc { relation viewer {} }")?;
+engine.touch_relationship("doc:readme#viewer@user:alice")?;
+engine.save_snapshot(&path, SnapshotSaveOptions::zstd())?;
+let loaded = ZanzibarEngine::load_snapshot(&path, SnapshotLoadOptions::zstd())?;
+# std::fs::remove_file(path).ok();
+# let _ = loaded;
+# Ok(())
+# }
+```
+
+## Testing and Verification
+
+Common checks:
 
 ```bash
-# Run all tests
-cargo test
-
-# Run specific test categories
-cargo test --test integration_tests
-cargo test --test storage_tests
-cargo test --test eval_tests
-cargo test --test parser_tests
-
-# Run with output
-cargo test -- --nocapture
+cargo build
+cargo test --all-features
+cargo +nightly fmt --check
+cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
+cargo audit
+cargo deny check
 ```
 
-## 🔍 Performance Considerations
+The Makefile keeps common automation discoverable:
 
-- **In-Memory Storage**: Current implementation uses `HashSet` for fast lookups
-- **Cycle Detection**: Prevents infinite recursion in policy evaluation
-- **Extensible Storage**: `TupleStore` trait allows custom storage backends
-- **Zero-Copy Parsing**: Efficient DSL parsing with `pest`
+```bash
+make check                 # build + nextest + fmt-check + clippy
+make bench-all             # full benchmark suite
+make bench-perf-continuous # focused continuous performance filters
+make perf-charts           # regenerate docs/perf SVGs from history.ndjson
+```
 
-## 🛣️ Roadmap
+The test suite includes unit, integration, property, snapshot-corruption, public API completeness,
+concurrent-runtime, e2e policy-to-snapshot, and benchmark harness coverage. The current performance
+report is in [`docs/perf/phase-15-complete-benchmark-2026-05-25.md`](docs/perf/phase-15-complete-benchmark-2026-05-25.md).
 
-- [ ] Persistent storage backends (PostgreSQL, Redis)
-- [ ] Metrics and observability
-- [ ] Policy validation and testing tools
-- [ ] Performance benchmarks
-- [ ] gRPC API server
-- [ ] Policy migration tools
+## Performance Notes
 
-## 🤝 Contributing
+- Relationship data is stored in compact indexed snapshots, not a linear `HashSet` scan on hot
+  paths.
+- Reads acquire a published immutable snapshot through `arc-swap` and reuse request-local evaluator
+  state where possible.
+- Writes are serialized through one bounded actor per engine; batch writes are much faster than many
+  single-relationship writes.
+- Raw `.szsnap` files optimize load speed. Zstd-wrapped snapshots optimize distribution size and are
+  decoded under a configured byte cap.
+- `IndexProfile::CheckOnly` can reduce artifact size when subject-side reverse lookup APIs are not
+  needed.
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+## Repository Map
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+- `src/api.rs`: public engine, writer actor, tenant sharding, public error model.
+- `src/domain.rs`: validated identifiers and relationship grammar.
+- `src/schema/`: schema compiler and resolver.
+- `src/relationship.rs`: compact relationship store and snapshot index encoding.
+- `src/eval.rs`: check, expand, lookup, memoization, and lookup planning.
+- `src/snapshot.rs`: raw and zstd snapshot save/load with validation.
+- `specs/`: product, design, performance, verification, and implementation specs.
+- `docs/perf/`: recorded benchmark evidence and generated charts.
 
-## 📄 License
+## Non-Goals
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE.md) file for details.
+- No persistent database backend in the current crate.
+- No network server or gRPC API.
+- No distributed consistency protocol.
+- No cryptographic signature implementation for snapshots; callers can use external integrity and
+  then select `SnapshotIntegrityMode::External` where appropriate.
 
-## 🙏 Acknowledgments
+## License
 
-- [Google's Zanzibar paper](https://research.google/pubs/pub48190/) for the foundational concepts
-- [OpenFGA](https://openfga.dev/) for inspiration on DSL design
-- The Rust community for excellent crates like `pest` and `thiserror`
+This project is licensed under the MIT License. See [LICENSE.md](LICENSE.md).
 
-## 📞 Support
+## Acknowledgments
 
-- 📖 [Documentation](https://docs.rs/simple-zanzibar)
-- 🐛 [Issue Tracker](https://github.com/tyrchen/simple-zanzibar/issues)
-- 💬 [Discussions](https://github.com/tyrchen/simple-zanzibar/discussions)
-
----
-
-**Simple Zanzibar** - Making authorization simple, scalable, and secure. 🔐
+- [Google's Zanzibar paper](https://research.google/pubs/pub48190/) for the authorization model.
+- [SpiceDB](https://github.com/authzed/spicedb) for production implementation patterns studied in
+  [`docs/research/study-spicedb.md`](docs/research/study-spicedb.md).

--- a/specs/72-testing-verification-plan.md
+++ b/specs/72-testing-verification-plan.md
@@ -55,6 +55,7 @@ This plan defines how each phase proves correctness, safety, compatibility, and 
 | Public API completeness | zstd snapshot round trips, policy text import/export, schema replacement/deletion, permission enumeration, and public API benchmarks for [19](./19-public-api-completeness-design.md). |
 | Concurrent runtime | lock-free read acquisition, writer actor lifecycle, failed-write atomicity, concurrent read/write behaviour, tenant isolation, and mixed workload benchmarks for [20](./20-concurrent-engine-runtime-design.md). |
 | Structural performance optimization | prepared-check equivalence, ID-native recursion, streaming lookup, segmented-store properties, index-profile support, snapshot phase timers, and 1M write/read benchmarks for [21](./21-performance-optimization-design.md). |
+| Production readiness | serde boundary rejection, policy-text-to-zstd-snapshot e2e flow, current README/API documentation, and Makefile production gate for [94](./94-production-readiness-review.md). |
 
 ## 4. Command Gates
 
@@ -62,11 +63,18 @@ Every implementation phase closes only when these pass:
 
 ```text
 cargo build
-cargo test
+cargo test --all-features
 cargo +nightly fmt --check
-cargo clippy -- -D warnings -W clippy::pedantic
+cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
 cargo audit
 cargo deny check
+RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+```
+
+The Makefile equivalent for release-hardening and production-readiness reviews is:
+
+```text
+make prod-ready-check
 ```
 
 For boundary-module hardening phases, also run:

--- a/specs/94-production-readiness-review.md
+++ b/specs/94-production-readiness-review.md
@@ -1,0 +1,97 @@
+# 94 - Production Readiness Review
+
+Status: draft v1
+Owner: Simple Zanzibar
+Last updated: 2026-05-25
+Depends on: [15](./15-public-api-design.md), [19](./19-public-api-completeness-design.md), [20](./20-concurrent-engine-runtime-design.md), [70](./70-security-design.md), [71](./71-performance-budgets-design.md), [72](./72-testing-verification-plan.md)
+
+## 1. Purpose
+
+This review turns the production-readiness pass into an implementation contract. It focuses on the
+four requested dimensions: test coverage, documentation freshness, public API ergonomics, and safety.
+The target state is not a new feature phase; it is a hardening pass that keeps existing Zanzibar
+semantics and performance budgets while closing concrete readiness gaps.
+
+## 2. Review Scope
+
+```text
+                   ┌────────────────────────────────────────┐
+                   │ Production readiness review            │
+                   ├────────────────────────────────────────┤
+                   │ 1. Tests: unit / integration / e2e /   │
+                   │    benchmark coverage                  │
+                   │ 2. Docs: README, specs, perf evidence  │
+                   │ 3. Public API: validated DTOs and      │
+                   │    discoverable verification commands  │
+                   │ 4. Safety: hostile-input boundaries,   │
+                   │    no unsafe, no production unwrap     │
+                   └──────────────┬─────────────────────────┘
+                                  │
+                    fixes must preserve existing behavior
+                                  │
+                                  ▼
+          ┌─────────────────────────────────────────────────┐
+          │ Verification gate                               │
+          │ cargo build / test --all-features / fmt /       │
+          │ pedantic clippy / audit / deny / docs / smoke   │
+          │ benchmarks                                      │
+          └─────────────────────────────────────────────────┘
+```
+
+## 3. Findings and Fix Contract
+
+| ID | Area | Finding | Fix shape | Exit evidence |
+| --- | --- | --- | --- | --- |
+| PRR-1 | Safety / serde | Public request DTOs derived `Deserialize` over raw `String` fields, so hostile JSON could build invalid `Object`, `Relation`, `User`, `LookupResourcesRequest.resource_type`, or `LookupSubjectsRequest.subject_type` values and defer rejection until later engine code. This violated [70](./70-security-design.md) and AGENTS.md boundary-validation rules. | Add validation methods to public DTOs, implement custom serde deserialization for domain-bearing DTOs, and validate requests before snapshot access in `ZanzibarEngine`. | New serde-boundary tests reject invalid object ids, resource types, and subject types before API execution. |
+| PRR-2 | E2E tests | Existing tests were strong at unit/integration/property/snapshot levels but lacked one end-to-end public flow that starts from reviewable policy text, exercises exact consistency and Zanzibar lookup behavior, saves a zstd snapshot, loads it, and proves equivalent answers. | Add an e2e test that covers policy text import, exclusion semantics, tuple-to-userset inheritance, permission enumeration, zstd snapshot save/load, and equivalence after load. | `tests/e2e_prod_readiness_tests.rs` passes under `cargo test --all-features`. |
+| PRR-3 | Documentation | README still described the older tuple-store architecture, `simple-zanzibar = "0.1.0"`, and hot-path `HashSet` storage, while the implementation now uses the concurrent engine, compact indexes, snapshot profiles, zstd, policy text, and Phase 15 perf evidence. | Rewrite README around the current public API, architecture, safety features, verification commands, and non-goals. | README no longer claims HashSet hot paths or missing benchmark support; it links the current performance report. |
+| PRR-4 | Verification automation | The Makefile had build/test/fmt/clippy and benchmark targets, but no single production-readiness gate that included pedantic clippy, audit, deny, and docs. | Add discoverable `prod-ready-check`, `audit`, `deny`, `doc`, and focused `bench-prod-smoke` targets. | `make prod-ready-check` is the documented local gate; benchmark smoke target covers representative read and snapshot load filters. |
+
+Known deferred performance backlog in [93](./93-improvements-review.md) remains valid and is not
+reclassified as a release blocker by this review: default safe full snapshot load is still tracked as
+an optimization item distinct from the trusted-fast cold-load path, which remains the production
+startup path for pre-verified artifacts.
+
+## 4. Test Coverage Assessment
+
+| Layer | Current coverage | Readiness decision |
+| --- | --- | --- |
+| Unit | Domain validation, schema/evaluator helpers, request memo behavior. | Sufficient for current API after PRR-1 serde-boundary additions. |
+| Integration | Check/expand/lookup semantics, consistency tokens, schema mutation atomicity, relationship preconditions. | Sufficient; PRR-2 adds a public e2e flow instead of duplicating existing integration cases. |
+| Property / randomized | Relationship-store equivalence and compact snapshot random direct relationship round trips. | Sufficient for the compact in-memory store scope. |
+| E2E | Previously scattered across public API and snapshot tests. | Add one explicit policy-to-zstd-snapshot e2e test. |
+| Benchmarks | Synthetic org, real-world auth, concurrent runtime, public API, snapshot, section-size, and read-follow-up allocation harnesses. | Sufficient; PRR-4 adds a smoke target for fast regression checks while `make bench-all` remains the full gate. |
+
+## 5. Verification Plan
+
+Required before this review is complete:
+
+1. `cargo build`
+2. `cargo test --all-features`
+3. `cargo +nightly fmt --check`
+4. `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
+5. `cargo audit`
+6. `cargo deny check`
+7. `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
+8. Focused benchmark smoke with representative read and snapshot-load filters.
+
+## 6. Implementation Evidence
+
+Local evidence captured on 2026-05-25 for this hardening pass:
+
+| Command | Result |
+| --- | --- |
+| `CARGO_TARGET_DIR=target/codex-review make prod-ready-check` | Passed: build, 152 nextest tests, fmt, pedantic clippy, audit, deny, and rustdoc. `cargo deny` emitted pre-existing warning-level duplicate/unmatched-license diagnostics and exited successfully. |
+| `CARGO_TARGET_DIR=target/codex-review PERF_SAMPLE_SIZE=10 make bench-prod-smoke` | Passed: `check_prepared_1m` high `4.4025 us`, `lookup_resources_streaming_1m` high `2.3653 ms`, `snapshot_load_trusted_fast/1m` high `179.98 ms` (still under the 200 ms trusted-fast gate). |
+| `cargo bench --bench public_api -- public_api/check/100k --sample-size 10` | Passed: high `2.0057 us`, still well under the 10 us public check gate after request validation. |
+| `cargo bench --bench public_api -- public_api/lookup_resources/100k --sample-size 10` | Passed: high `2.4869 ms`, still under the 10 ms public lookup gate. |
+
+## 7. Cross-References
+
+- Public API design: [15-public-api-design.md](./15-public-api-design.md)
+- Public API completeness: [19-public-api-completeness-design.md](./19-public-api-completeness-design.md)
+- Concurrent runtime: [20-concurrent-engine-runtime-design.md](./20-concurrent-engine-runtime-design.md)
+- Security model: [70-security-design.md](./70-security-design.md)
+- Performance budgets: [71-performance-budgets-design.md](./71-performance-budgets-design.md)
+- Verification plan: [72-testing-verification-plan.md](./72-testing-verification-plan.md)
+- Deferred findings: [93-improvements-review.md](./93-improvements-review.md)

--- a/specs/index.md
+++ b/specs/index.md
@@ -1,7 +1,7 @@
 # Specs Index
 
 Status: draft v1
-Last updated: 2026-05-24
+Last updated: 2026-05-25
 
 This directory now has two generations of design material:
 
@@ -46,6 +46,7 @@ Read the v2 specs in numeric order. The order is also the implementation depende
 | [90-local-engine-roadmap.md](./90-local-engine-roadmap.md) | Roadmap | Stakeholder-facing milestones and observable exit criteria. |
 | [91-local-engine-impl-plan.md](./91-local-engine-impl-plan.md) | Implementation plan | Engineer-facing, dependency-ordered phases with task gates. |
 | [93-improvements-review.md](./93-improvements-review.md) | Review backlog | Deferred review findings and out-of-phase follow-up implementation items. |
+| [94-production-readiness-review.md](./94-production-readiness-review.md) | Review | Production-readiness findings, fix contract, and verification gate for tests, docs, public API, and safety. |
 | [99-key-decisions.md](./99-key-decisions.md) | Decisions | Load-bearing design choices, alternatives, and rationale. |
 
 ## Build-Order Graph
@@ -161,7 +162,21 @@ Read the v2 specs in numeric order. The order is also the implementation depende
                   +-------------------------+          +----------------------+
                   | 90 Roadmap              | <------> | 91 Impl Plan         |
                   | stakeholder milestones  |          | engineering phases   |
-                  +-------------------------+          +----------------------+
+                  +------------+------------+          +----------+-----------+
+                               |                                  |
+                               +----------------+-----------------+
+                                                |
+                                                v
+                                    +----------------------+
+                                    | 93/94 Reviews        |
+                                    | backlog + prod gate  |
+                                    +----------+-----------+
+                                               |
+                                               v
+                                    +----------------------+
+                                    | 99 Key Decisions     |
+                                    | rationale ledger     |
+                                    +----------------------+
 ```
 
 ## Required Prior Art

--- a/src/api.rs
+++ b/src/api.rs
@@ -74,6 +74,7 @@ impl ZanzibarEngine {
     /// fails.
     pub fn check(&self, request: CheckRequest) -> Result<CheckResponse, EngineError> {
         enter_api_span!("check");
+        request.validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(request.consistency)?;
         let object_type = ObjectType::try_from(request.object.namespace.as_str())?;
         let relation_name = RelationName::try_from(request.relation.0.as_str())?;
@@ -157,6 +158,7 @@ impl ZanzibarEngine {
     /// fails.
     pub fn expand(&self, request: ExpandRequest) -> Result<ExpandResponse, EngineError> {
         enter_api_span!("expand");
+        request.validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(request.consistency)?;
         let object_type = ObjectType::try_from(request.object.namespace.as_str())?;
         let relation_name = RelationName::try_from(request.relation.0.as_str())?;
@@ -213,6 +215,7 @@ impl ZanzibarEngine {
         consistency: Consistency,
     ) -> Result<LookupResources, EngineError> {
         enter_api_span!("lookup_resources");
+        request.borrow().validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(consistency)?;
         Self::ensure_subject_reverse_lookup_supported(&snapshot, "lookup_resources")?;
         let request = request.borrow();
@@ -245,6 +248,7 @@ impl ZanzibarEngine {
         consistency: Consistency,
     ) -> Result<LookupSubjects, EngineError> {
         enter_api_span!("lookup_subjects");
+        request.borrow().validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(consistency)?;
         let request = request.borrow();
         Ok(eval::lookup_subjects_with_snapshot(
@@ -623,6 +627,7 @@ impl ZanzibarEngine {
     ) -> Result<LookupPermissions, EngineError> {
         enter_api_span!("lookup_permissions");
         let request = request.borrow();
+        request.validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(request.consistency.clone())?;
         let object_type = ObjectType::try_from(request.resource.namespace.as_str())?;
         snapshot.schema().resolver().namespace(&object_type)?;
@@ -661,6 +666,7 @@ impl ZanzibarEngine {
     ) -> Result<LookupObjectPermissions, EngineError> {
         enter_api_span!("lookup_object_permissions");
         let request = request.borrow();
+        request.validate()?;
         let (snapshot, limits) = self.snapshot_for_consistency(request.consistency.clone())?;
         let object_type = ObjectType::try_from(request.resource.namespace.as_str())?;
         snapshot.schema().resolver().namespace(&object_type)?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,13 +2,18 @@
 
 use std::hash::Hash;
 
-use crate::revision::Consistency;
+use crate::{
+    domain::{
+        DomainError, ObjectRef, ObjectType, RelationName, Relationship, SubjectRef, SubjectType,
+    },
+    revision::Consistency,
+};
 
 /// Represents a namespaced digital object.
 /// e.g., `doc:readme`, `folder:A`
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,11 +33,44 @@ impl Object {
             id: id.into(),
         }
     }
+
+    /// Validates this object's namespace and identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the namespace or object id violates the public identifier
+    /// grammar or byte limits.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        ObjectRef::try_from(self).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Object {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct ObjectSerde {
+            namespace: String,
+            id: String,
+        }
+
+        let value = ObjectSerde::deserialize(deserializer)?;
+        let object = Self {
+            namespace: value.namespace,
+            id: value.id,
+        };
+        object.validate().map_err(serde::de::Error::custom)?;
+        Ok(object)
+    }
 }
 
 /// Represents a relation or permission type on an object.
 /// e.g., `owner`, `editor`, `viewer`
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Relation(pub String);
 
@@ -42,18 +80,40 @@ impl Relation {
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
+
+    /// Validates this relation or permission name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the relation violates the public relation-name grammar or byte
+    /// limit.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        RelationName::try_from(self).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Relation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let relation = Self(<String as serde::Deserialize>::deserialize(deserializer)?);
+        relation.validate().map_err(serde::de::Error::custom)?;
+        Ok(relation)
+    }
 }
 
 /// Represents either a specific user ID or a reference to a userset (e.g., a group).
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", tag = "type", content = "value")
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum User {
     /// A specific user, identified by a unique string.
-    /// e.g., `"10"`, `"alice@example.com"`
+    /// e.g., `"10"`, `"alice"`.
     UserId(String),
     /// A set of users, identified by an object-relation pair.
     /// e.g., `group:eng#member`
@@ -72,6 +132,38 @@ impl User {
     pub fn userset(object: Object, relation: Relation) -> Self {
         Self::Userset(object, relation)
     }
+
+    /// Validates this subject reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when a direct user id or userset object/relation violates public
+    /// identifier grammar or byte limits.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        SubjectRef::try_from(self).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for User {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", tag = "type", content = "value")]
+        enum UserSerde {
+            UserId(String),
+            Userset(Object, Relation),
+        }
+
+        let user = match UserSerde::deserialize(deserializer)? {
+            UserSerde::UserId(id) => Self::UserId(id),
+            UserSerde::Userset(object, relation) => Self::Userset(object, relation),
+        };
+        user.validate().map_err(serde::de::Error::custom)?;
+        Ok(user)
+    }
 }
 
 /// The core relation tuple, representing a single permission assertion.
@@ -79,7 +171,7 @@ impl User {
 /// e.g., `(doc:readme#owner@user:alice)`
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -101,6 +193,41 @@ impl RelationTuple {
             relation,
             user,
         }
+    }
+
+    /// Validates this relationship tuple.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when any tuple component violates public identifier grammar or byte
+    /// limits.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        Relationship::try_from(self).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for RelationTuple {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct RelationTupleSerde {
+            object: Object,
+            relation: Relation,
+            user: User,
+        }
+
+        let value = RelationTupleSerde::deserialize(deserializer)?;
+        let tuple = Self {
+            object: value.object,
+            relation: value.relation,
+            user: value.user,
+        };
+        tuple.validate().map_err(serde::de::Error::custom)?;
+        Ok(tuple)
     }
 }
 
@@ -132,6 +259,17 @@ impl CheckRequest {
             user,
             consistency,
         }
+    }
+
+    /// Validates domain fields in this check request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the object, relation, or subject is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.object.validate()?;
+        self.relation.validate()?;
+        self.user.validate()
     }
 }
 
@@ -173,6 +311,16 @@ impl ExpandRequest {
             consistency,
         }
     }
+
+    /// Validates domain fields in this expand request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the object or relation is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.object.validate()?;
+        self.relation.validate()
+    }
 }
 
 /// Response for an expand request.
@@ -190,7 +338,7 @@ pub struct ExpandResponse {
 /// Request for resources of one type that a subject can access through a permission.
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -213,6 +361,42 @@ impl LookupResourcesRequest {
             resource_type: resource_type.into(),
         }
     }
+
+    /// Validates domain fields in this lookup request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the subject, permission, or resource type is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.subject.validate()?;
+        self.permission.validate()?;
+        ObjectType::try_from(self.resource_type.as_str()).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LookupResourcesRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct LookupResourcesRequestSerde {
+            subject: User,
+            permission: Relation,
+            resource_type: String,
+        }
+
+        let value = LookupResourcesRequestSerde::deserialize(deserializer)?;
+        let request = Self {
+            subject: value.subject,
+            permission: value.permission,
+            resource_type: value.resource_type,
+        };
+        request.validate().map_err(serde::de::Error::custom)?;
+        Ok(request)
+    }
 }
 
 /// Resources returned by a lookup request.
@@ -230,7 +414,7 @@ pub struct LookupResources {
 /// Request for subjects of one type that can access a resource through a permission.
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -252,6 +436,42 @@ impl LookupSubjectsRequest {
             permission,
             subject_type: subject_type.into(),
         }
+    }
+
+    /// Validates domain fields in this lookup request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the resource, permission, or subject type is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.resource.validate()?;
+        self.permission.validate()?;
+        SubjectType::try_from(self.subject_type.as_str()).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LookupSubjectsRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct LookupSubjectsRequestSerde {
+            resource: Object,
+            permission: Relation,
+            subject_type: String,
+        }
+
+        let value = LookupSubjectsRequestSerde::deserialize(deserializer)?;
+        let request = Self {
+            resource: value.resource,
+            permission: value.permission,
+            subject_type: value.subject_type,
+        };
+        request.validate().map_err(serde::de::Error::custom)?;
+        Ok(request)
     }
 }
 
@@ -293,6 +513,16 @@ impl LookupPermissionsRequest {
             consistency,
         }
     }
+
+    /// Validates domain fields in this lookup request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the subject or resource is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.subject.validate()?;
+        self.resource.validate()
+    }
 }
 
 /// Permissions returned by a subject/resource lookup request.
@@ -310,7 +540,7 @@ pub struct LookupPermissions {
 /// Request for subjects grouped by every permission they have on one resource.
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
+    derive(serde::Serialize),
     serde(rename_all = "camelCase", deny_unknown_fields)
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -336,6 +566,41 @@ impl LookupObjectPermissionsRequest {
             subject_type: subject_type.into(),
             consistency,
         }
+    }
+
+    /// Validates domain fields in this lookup request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DomainError`] when the resource or subject type is invalid.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        self.resource.validate()?;
+        SubjectType::try_from(self.subject_type.as_str()).map(drop)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LookupObjectPermissionsRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct LookupObjectPermissionsRequestSerde {
+            resource: Object,
+            subject_type: String,
+            consistency: Consistency,
+        }
+
+        let value = LookupObjectPermissionsRequestSerde::deserialize(deserializer)?;
+        let request = Self {
+            resource: value.resource,
+            subject_type: value.subject_type,
+            consistency: value.consistency,
+        };
+        request.validate().map_err(serde::de::Error::custom)?;
+        Ok(request)
     }
 }
 

--- a/tests/e2e_prod_readiness_tests.rs
+++ b/tests/e2e_prod_readiness_tests.rs
@@ -1,0 +1,198 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use simple_zanzibar::{
+    PolicyText, SnapshotLoadOptions, SnapshotSaveOptions, ZanzibarEngine,
+    model::{
+        CheckRequest, LookupObjectPermissionsRequest, LookupPermissionsRequest,
+        LookupResourcesRequest, LookupSubjectsRequest, Object, PermissionSubjects, Relation, User,
+    },
+    revision::Consistency,
+};
+
+static NEXT_TEST_PATH: AtomicU64 = AtomicU64::new(1);
+
+#[test]
+fn test_should_run_reviewable_policy_to_snapshot_e2e() -> Result<(), Box<dyn std::error::Error>> {
+    let policy = PolicyText::from_single_relationship_file(
+        schema().to_string(),
+        [
+            "folder:root#viewer@group:eng#member",
+            "group:eng#member@user:alice",
+            "doc:readme#parent@folder:root#viewer",
+            "doc:secret#parent@folder:root#viewer",
+            "doc:secret#banned@user:alice",
+        ]
+        .join("\n"),
+    );
+    let engine = ZanzibarEngine::from_policy_text(&policy)?;
+    let alice = User::user_id("alice");
+    let readme = object("doc", "readme");
+    let secret = object("doc", "secret");
+
+    let token = engine.touch_relationship("doc:readme#owner@user:bob")?;
+    assert!(
+        engine
+            .check(CheckRequest::new(
+                readme.clone(),
+                relation("viewer"),
+                alice.clone(),
+                Consistency::Exact(token),
+            ))?
+            .allowed
+    );
+    assert!(
+        !engine
+            .check(CheckRequest::new(
+                secret.clone(),
+                relation("viewer"),
+                alice.clone(),
+                Consistency::Latest,
+            ))?
+            .allowed
+    );
+    assert_eq!(
+        engine
+            .lookup_resources(LookupResourcesRequest::new(
+                alice.clone(),
+                relation("viewer"),
+                "doc",
+            ))?
+            .resources,
+        vec![readme.clone()],
+    );
+    assert_eq!(
+        engine
+            .lookup_subjects(LookupSubjectsRequest::new(
+                readme.clone(),
+                relation("viewer"),
+                "user",
+            ))?
+            .subjects,
+        vec![User::user_id("bob"), User::user_id("alice")],
+    );
+    assert_eq!(
+        engine
+            .lookup_permissions(LookupPermissionsRequest::new(
+                User::user_id("bob"),
+                readme.clone(),
+                Consistency::Latest,
+            ))?
+            .permissions,
+        vec![relation("owner"), relation("viewer")],
+    );
+    assert_eq!(
+        engine
+            .lookup_object_permissions(LookupObjectPermissionsRequest::new(
+                readme.clone(),
+                "user",
+                Consistency::Latest,
+            ))?
+            .permissions,
+        vec![
+            PermissionSubjects {
+                permission: relation("owner"),
+                subjects: vec![User::user_id("bob")],
+            },
+            PermissionSubjects {
+                permission: relation("parent"),
+                subjects: vec![User::user_id("alice")],
+            },
+            PermissionSubjects {
+                permission: relation("viewer"),
+                subjects: vec![User::user_id("bob"), User::user_id("alice")],
+            },
+        ],
+    );
+
+    let snapshot_path = temp_snapshot_path("prod_e2e");
+    engine.save_snapshot(&snapshot_path, SnapshotSaveOptions::zstd())?;
+    let loaded = ZanzibarEngine::load_snapshot(&snapshot_path, SnapshotLoadOptions::zstd())?;
+    remove_file(&snapshot_path)?;
+
+    assert_equivalent_queries(&engine, &loaded, &readme, &secret, &alice)?;
+    Ok(())
+}
+
+fn assert_equivalent_queries(
+    left: &ZanzibarEngine,
+    right: &ZanzibarEngine,
+    readme: &Object,
+    secret: &Object,
+    alice: &User,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for engine in [left, right] {
+        assert!(engine.check_relation(readme, &relation("viewer"), alice)?);
+        assert!(!engine.check_relation(secret, &relation("viewer"), alice)?);
+        assert_eq!(
+            engine
+                .lookup_resources(LookupResourcesRequest::new(
+                    alice.clone(),
+                    relation("viewer"),
+                    "doc",
+                ))?
+                .resources,
+            vec![readme.clone()],
+        );
+    }
+    Ok(())
+}
+
+fn schema() -> &'static str {
+    r#"
+    namespace user {
+        relation member {}
+    }
+
+    namespace group {
+        relation member {}
+    }
+
+    namespace folder {
+        relation viewer {}
+    }
+
+    namespace doc {
+        relation owner {}
+        relation parent {}
+        relation banned {}
+        relation viewer {
+            rewrite exclusion(
+                union(
+                    computed_userset(relation: "owner"),
+                    tuple_to_userset(tupleset: "parent", computed_userset: "viewer")
+                ),
+                computed_userset(relation: "banned")
+            )
+        }
+    }
+    "#
+}
+
+fn object(namespace: &str, id: &str) -> Object {
+    Object::new(namespace, id)
+}
+
+fn relation(name: &str) -> Relation {
+    Relation::new(name)
+}
+
+fn temp_snapshot_path(prefix: &str) -> PathBuf {
+    let sequence = NEXT_TEST_PATH.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "simple-zanzibar-{prefix}-{}-{sequence}.szsnap.zst",
+        process::id(),
+    ))
+}
+
+fn remove_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Box::new(error)),
+    }
+}

--- a/tests/engine_tests.rs
+++ b/tests/engine_tests.rs
@@ -154,6 +154,20 @@ fn test_should_use_public_engine_request_response_api() -> Result<(), Box<dyn st
 }
 
 #[test]
+fn test_should_validate_public_requests_before_snapshot_access() {
+    let engine = ZanzibarEngine::builder().build();
+
+    let result = engine.check(CheckRequest::new(
+        Object::new("doc", "bad id"),
+        viewer(),
+        User::user_id("alice"),
+        Consistency::Latest,
+    ));
+
+    assert!(matches!(result, Err(EngineError::Domain(_))));
+}
+
+#[test]
 fn test_should_persist_direct_non_user_subject_relationships()
 -> Result<(), Box<dyn std::error::Error>> {
     let engine = ZanzibarEngine::builder().build();
@@ -313,6 +327,41 @@ fn test_should_serialize_public_request_dtos_with_camel_case()
 #[test]
 fn test_should_validate_domain_values_during_deserialization() {
     let result: Result<Relationship, _> = serde_json::from_str(r#""doc:bad id#viewer@user:alice""#);
+    let invalid_check: Result<CheckRequest, _> = serde_json::from_value(serde_json::json!({
+        "object": {
+            "namespace": "doc",
+            "id": "bad id",
+        },
+        "relation": "viewer",
+        "user": {
+            "type": "userId",
+            "value": "alice",
+        },
+        "consistency": {
+            "kind": "latest",
+        },
+    }));
+    let invalid_lookup_resources: Result<LookupResourcesRequest, _> =
+        serde_json::from_value(serde_json::json!({
+            "subject": {
+                "type": "userId",
+                "value": "alice",
+            },
+            "permission": "viewer",
+            "resourceType": "bad-type",
+        }));
+    let invalid_lookup_subjects: Result<LookupSubjectsRequest, _> =
+        serde_json::from_value(serde_json::json!({
+            "resource": {
+                "namespace": "doc",
+                "id": "readme",
+            },
+            "permission": "viewer",
+            "subjectType": "bad type",
+        }));
 
     assert!(result.is_err());
+    assert!(invalid_check.is_err());
+    assert!(invalid_lookup_resources.is_err());
+    assert!(invalid_lookup_subjects.is_err());
 }


### PR DESCRIPTION
## Summary

- Add a production-readiness review spec covering tests, docs, public API, safety findings, fixes, and verification evidence.
- Validate public model/request DTOs at the serde boundary and before snapshot access in the public engine APIs.
- Add an e2e policy-text -> Zanzibar behavior -> zstd snapshot round-trip test.
- Refresh the README to match the current concurrent compact-snapshot engine and add Makefile production gates / benchmark smoke targets.

## Verification

- `CARGO_TARGET_DIR=target/codex-review make prod-ready-check`
- `CARGO_TARGET_DIR=target/codex-review cargo test --all-features`
- `CARGO_TARGET_DIR=target/codex-review cargo +nightly fmt --check`
- `CARGO_TARGET_DIR=target/codex-review cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `CARGO_TARGET_DIR=target/codex-review RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps`
- `cargo audit && cargo deny check` (deny exits successfully with existing warning-level duplicate/unmatched-license diagnostics)
- `CARGO_TARGET_DIR=target/codex-review PERF_SAMPLE_SIZE=10 make bench-prod-smoke`
- `CARGO_TARGET_DIR=target/codex-review cargo bench --bench public_api -- public_api/check/100k --sample-size 10`
- `CARGO_TARGET_DIR=target/codex-review cargo bench --bench public_api -- public_api/lookup_resources/100k --sample-size 10`
